### PR TITLE
Static file server should not send content-length header when returning a 304 not modified

### DIFF
--- a/lib/cube/server/endpoint.js
+++ b/lib/cube/server/endpoint.js
@@ -50,13 +50,21 @@ function file() {
     function respond() {
       var status = modified <= new Date(request.headers["if-modified-since"]) ? 304 : 200;
 
-      response.writeHead(status, {
-        "Content-Type": type + ";charset=utf-8",
-        "Content-Length": size,
-        "Last-Modified": modified.toUTCString()
-      });
+      var hasBody = (status == 200) && (request.method !== "HEAD");
 
-      if ((status === 200) && (request.method !== "HEAD")) {
+      var headers = {
+        "Content-Type": type + ";charset=utf-8",
+        "Date": new(Date)().toUTCString(),
+        "Last-Modified": modified.toUTCString()
+      };
+
+      if (hasBody) {
+        headers["Content-Length"] = size;
+      }
+
+      response.writeHead(status, headers);
+
+      if (hasBody) {
         return read(0);
       }
 


### PR DESCRIPTION
It breaks on Safari 5.0.x, which hangs while waiting for the rest of the request.
See RFC 2616 section 4.3.

This doesn't include a test, as I wasn't sure what you wanted to use for testing the request cycle, but can add one if you'd like.
