### PR TITLE
Allow POSTing a single event.

### DIFF
--- a/lib/cube/server/collector.js
+++ b/lib/cube/server/collector.js
@@ -20,7 +20,19 @@ function post(putter) {
     });
     request.on("end", function() {
       try {
-        JSON.parse(content).forEach(putter);
+        var eventData = JSON.parse(content);
+        // We'll accept both arrays and objects as the root value of the posted
+        // JSON. If it has a defined forEach key, we'll assume it's an array. If
+        // not, then we'll pass it to putter if it's an object, otherwise we'll
+        // throw an error.
+        if (eventData.forEach !== undefined) {
+          eventData.forEach(putter);
+        } else if (typeof(eventData) === "object") {
+          putter(eventData);
+        } else {
+          var type = typeof(eventData);
+          throw(new Error("I don't know what to do with a " + type));
+        }
       } catch (e) {
         util.log(e);
         response.writeHead(400, {

--- a/lib/cube/server/collector.js
+++ b/lib/cube/server/collector.js
@@ -20,19 +20,7 @@ function post(putter) {
     });
     request.on("end", function() {
       try {
-        var eventData = JSON.parse(content);
-        // We'll accept both arrays and objects as the root value of the posted
-        // JSON. If it has a defined forEach key, we'll assume it's an array. If
-        // not, then we'll pass it to putter if it's an object, otherwise we'll
-        // throw an error.
-        if (eventData.forEach !== undefined) {
-          eventData.forEach(putter);
-        } else if (typeof(eventData) === "object") {
-          putter(eventData);
-        } else {
-          var type = typeof(eventData);
-          throw(new Error("I don't know what to do with a " + type));
-        }
+        JSON.parse(content).forEach(putter);
       } catch (e) {
         util.log(e);
         response.writeHead(400, {

--- a/test/collector-test.js
+++ b/test/collector-test.js
@@ -36,9 +36,9 @@ suite.addBatch(test.batch({
 suite.addBatch(test.batch({
   "POST /event/put with a JSON object": {
     topic: test.request({method: "POST", port: port, path: "/1.0/event/put"}, JSON.stringify(obj)),
-    "responds with status 200": function(response) {
-      assert.equal(response.statusCode, 200);
-      assert.deepEqual(JSON.parse(response.body), {status: 200});
+    "responds with status 400": function(response) {
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(JSON.parse(response.body), {status: 400});
     }
   }
 }));

--- a/test/collector-test.js
+++ b/test/collector-test.js
@@ -12,6 +12,13 @@ var port = ++test.port, server = cube.server({
   "http-port": port
 });
 
+var obj = { type: "test"
+          , time: (new Date).toISOString()
+          , data: { foo: "bar" }
+          };
+var arr = [obj];
+var num = 42;
+
 server.register = cube.collector.register;
 
 server.start();
@@ -19,6 +26,36 @@ server.start();
 suite.addBatch(test.batch({
   "POST /event/put with invalid JSON": {
     topic: test.request({method: "POST", port: port, path: "/1.0/event/put"}, "This ain't JSON.\n"),
+    "responds with status 400": function(response) {
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(JSON.parse(response.body), {status: 400});
+    }
+  }
+}));
+
+suite.addBatch(test.batch({
+  "POST /event/put with a JSON object": {
+    topic: test.request({method: "POST", port: port, path: "/1.0/event/put"}, JSON.stringify(obj)),
+    "responds with status 200": function(response) {
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {status: 200});
+    }
+  }
+}));
+
+suite.addBatch(test.batch({
+  "POST /event/put with a JSON array": {
+    topic: test.request({method: "POST", port: port, path: "/1.0/event/put"}, JSON.stringify(arr)),
+    "responds with status 200": function(response) {
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {status: 200});
+    }
+  }
+}));
+
+suite.addBatch(test.batch({
+  "POST /event/put with a JSON number": {
+    topic: test.request({method: "POST", port: port, path: "/1.0/event/put"}, JSON.stringify(num)),
     "responds with status 400": function(response) {
       assert.equal(response.statusCode, 400);
       assert.deepEqual(JSON.parse(response.body), {status: 400});

--- a/test/test.js
+++ b/test/test.js
@@ -67,7 +67,7 @@ exports.request = function(options, data) {
 
     request.on("error", function(e) { cb(e, null); });
 
-    if (arguments.length > 1) request.write(data);
+    if (data && data.length > 0) request.write(data);
     request.end();
   };
 };


### PR DESCRIPTION
The collector now allows a single event object to be posted, as well as an array of event objects. Tests are included.

I also fixed a bug in `test.js` where no data would be sent to the server by the `test.request()` method. Previously, the returned closure checked for the presence of a data argument by looking at the value of `arguments.length`, but since it was a closure with no arguments, this didn't quite work. I modified the test to check that the enclosed data argument is truthy and has a length greater than zero.
