### PR TITLE
Add UDP collector support

### DIFF
--- a/bin/collector-config.js
+++ b/bin/collector-config.js
@@ -3,5 +3,6 @@ module.exports = {
   "mongo-host": "127.0.0.1",
   "mongo-port": 27017,
   "mongo-database": "cube_development",
-  "http-port": 1080
+  "http-port": 1080,
+  "udp-port": 1180
 };

--- a/examples/emitter/random/random-config.js
+++ b/examples/emitter/random/random-config.js
@@ -1,5 +1,7 @@
 // Default configuration for development.
 module.exports = {
   "http-host": "127.0.0.1",
-  "http-port": 1080
+  "http-port": 1080,
+  "udp-host" : "127.0.0.1",
+  "udp-port" : 1180
 };

--- a/examples/emitter/random/random-udp.js
+++ b/examples/emitter/random/random-udp.js
@@ -1,0 +1,47 @@
+var util = require("util"),
+    dgram = require('dgram'),
+    options = require("./random-config"),
+    count = 0,
+    batch = 10,
+    hour = 60 * 60 * 1000,
+    start = Date.now(),
+    offset = -Math.abs(random()) * 24 * hour;
+
+// Emit random values.
+var interval = setInterval(function() {
+  for (var i = -1; ++i < batch;) {
+    send({
+      type: "random",
+      time: new Date(Date.now() + random() * 2 * hour + offset),
+      data: {random: (offset & 1 ? 1 : -1) * Math.random()}
+    });
+    count++;
+  }
+  var duration = Date.now() - start;
+  console.log(count + " events in " + duration + " ms: " + Math.round(1000 * count / duration) + " sps");
+}, 10);
+
+// Display stats on shutdown.
+process.on("SIGINT", function() {
+  clearInterval(interval);
+});
+
+// Sample from a normal distribution with mean 0, stddev 1.
+function random() {
+  var x = 0, y = 0, r;
+  do {
+    x = Math.random() * 2 - 1;
+    y = Math.random() * 2 - 1;
+    r = x * x + y * y;
+  } while (!r || r > 1);
+  return x * Math.sqrt(-2 * Math.log(r) / r);
+}
+
+//Send the data via the udp client.
+function send(data) {
+  var message = new Buffer(JSON.stringify(data));
+  var client = dgram.createSocket("udp4");
+  client.send(message, 0, message.length, options["udp-port"], options["udp-host"], function(error, bytes) {
+    client.close();
+  });
+}

--- a/lib/cube/server/collector.js
+++ b/lib/cube/server/collector.js
@@ -10,6 +10,11 @@ exports.register = function(db, endpoints) {
     endpoint.exact("POST", "/1.0/event/put", post(putter)),
     endpoint.exact("POST", "/collectd", require("./collectd").putter(putter))
   );
+  endpoints.udp.push(
+    {
+      dispatch: putter
+    }
+  );
 };
 
 function post(putter) {

--- a/lib/cube/server/server.js
+++ b/lib/cube/server/server.js
@@ -1,6 +1,7 @@
 var util = require("util"),
     url = require("url"),
     http = require("http"),
+    dgram = require("dgram"),
     websocket = require("websocket"),
     websprocket = require("websocket-server"),
     mongodb = require("mongodb");
@@ -30,7 +31,8 @@ module.exports = function(options) {
   var server = {},
       primary = http.createServer(),
       secondary = websprocket.createServer(),
-      endpoints = {ws: [], http: []},
+      udp = dgram.createSocket("udp4"),
+      endpoints = {ws: [], http: [], udp: []},
       mongo = new mongodb.Server(options["mongo-host"], options["mongo-port"]),
       db = new mongodb.Db(options["mongo-database"], mongo),
       id = 0;
@@ -117,6 +119,15 @@ module.exports = function(options) {
     response.end("404 Not Found");
   });
 
+  // Register UDP listener.
+  udp.on("message", function (message, rinfo) {
+    try {
+      endpoints.udp[0].dispatch(JSON.parse(message.toString('utf8')));
+    } catch (error) {
+      util.log("failed to interpret message - " + error);
+    }
+  });
+
   server.start = function() {
     // Connect to mongodb.
     util.log("starting mongodb client");
@@ -128,6 +139,15 @@ module.exports = function(options) {
     // Start the server!
     util.log("starting http server on port " + options["http-port"]);
     primary.listen(options["http-port"]);
+
+    //Start the UDP server! ... if configured.
+    if (options["udp-port"]) {
+      util.log("starting udp server on port " + options["udp-port"]);
+      udp.on("error", function (error) {
+        util.log("failed to bind to UDP port - " + error)
+      });
+      udp.bind(options["udp-port"]);
+    }
   };
 
   return server;


### PR DESCRIPTION
This pull request will start a UDP server port on the collector if configured to do so.  A new option, "udp-port" has been placed into the collector-config.js; with this property in place the server port will open.  The udp server expects one event per request.  An example emitter can be found at emitter/random/random-udp.js.  This emitter is just a modification of the random emitter to use UDP instead of websockets.
