### PR TITLE
Added support for replicaSet mongo setup

### DIFF
--- a/lib/cube/server/server.js
+++ b/lib/cube/server/server.js
@@ -27,11 +27,22 @@ var wsOptions =  {
 };
 
 module.exports = function(options) {
+  if (options["mongo-hosts"]) {
+    var mongoServers = []
+    for (var i = 0; i < options["mongo-hosts"].length; i++) {
+      server_opt = options["mongo-hosts"][i]
+      mongoServers.push(new mongodb.Server(server_opt[0], parseInt(server_opt[1]), server_opt[2]))
+    }
+    var mongo = new mongodb.ReplSetServers(mongoServers,
+    { read_secondary: true });
+  } else {
+    var mongo = new mongodb.Server(options["mongo-host"], options["mongo-port"])
+  }
+
   var server = {},
       primary = http.createServer(),
       secondary = websprocket.createServer(),
       endpoints = {ws: [], http: []},
-      mongo = new mongodb.Server(options["mongo-host"], options["mongo-port"]),
       db = new mongodb.Db(options["mongo-database"], mongo),
       id = 0;
 


### PR DESCRIPTION
Add support for replicaSet mongo setups by passing in an array of server parameters in the form of [<hostname>, <port>, <options>] to the options hash key 'mongo-hosts' 

eg.
[
    ['db1.domain.com', 27017, { auto_reconnect: true, slave_ok: true }
    ['db2.domain.com', 27017, { auto_reconnect: true, slave_ok: true }
    ...
]
