### PR TITLE
Add html blocks

### DIFF
--- a/lib/cube/client/piece-html.js
+++ b/lib/cube/client/piece-html.js
@@ -1,0 +1,69 @@
+cube.piece.type.html = function(board) {
+  var timeout;
+
+  var html = cube.piece(board)
+      .on("size", resize)
+      .on("serialize", serialize)
+      .on("deserialize", deserialize);
+
+  var div = d3.select(html.node())
+      .classed("html", true);
+
+  if (mode == "edit") {
+    div.append("h3")
+        .attr("class", "title")
+        .text("HTML Block");
+
+    var content = div.append("textarea")
+        .attr("class", "content")
+        .attr("placeholder", "html content…")
+        .on("keyup.html", htmlchange)
+        .on("focus.html", html.focus)
+        .on("blur.html", html.blur);
+  } else {
+    div
+        .style("text-align", "left");
+  }
+
+  function resize() {
+    var transition = html.transition(),
+        innerSize = html.innerSize();
+
+    if (mode == "edit") {
+      transition.select(".content")
+          .style("width", innerSize[0] - 12 + "px")
+          .style("height", innerSize[1] - 34 + "px");
+    } else {
+      transition
+          .style("font-size", innerSize[0] / 12 + "px")
+          .style("margin-top", "0px");
+          //.style("margin-top", innerSize[1] / 2 + innerSize[0] / 5 - innerSize[0] / 12 + "px");
+    }
+  }
+
+  function htmlchange() {
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(html.edit, 750);
+  }
+
+  function serialize(json) {
+    json.type = "html";
+    json.content = content.property("value");
+  }
+
+  function deserialize(json) {
+    if (mode == "edit") {
+      content.property("value", json.content);
+    } else {
+      div.html(json.content);
+    }
+  }
+
+  html.copy = function() {
+    return board.add(cube.piece.type.html);
+  };
+
+  resize();
+
+  return html;
+};

--- a/lib/cube/server/visualizer.js
+++ b/lib/cube/server/visualizer.js
@@ -16,6 +16,7 @@ exports.register = function(db, endpoints) {
       resolve("piece-area.js"),
       resolve("piece-sum.js"),
       resolve("piece-text.js"),
+      resolve("piece-html.js"),
       resolve("palette.js"),
       resolve("squares.js"),
       resolve("board.js"),


### PR DESCRIPTION
This pull request adds another block type, HTML blocks.  They act just like text blocks but render as HTML.  We use this to add a logo to the dashboard, as well as to add inline css to style the page.

While our cube server is not externally accessible and I assume it is meant to only be used that way, it's probably worth noting that allowing other people to inject HTML into your site has security implications.
