### PR TITLE
Fix conversion of collectd timestamps

### DIFF
--- a/lib/cube/server/collectd.js
+++ b/lib/cube/server/collectd.js
@@ -65,7 +65,7 @@ exports.putter = function(putter) {
     });
     request.on("end", function() {
       JSON.parse(content).forEach(function(value) {
-        value.time = Math.round(value.time / 1073741824) * 1000;
+        value.time = (+value.time) * 1000;
         queue.push(value);
       });
       response.writeHead(200);


### PR DESCRIPTION
I am not sure why timestamps from collectd were being divided by this very large magic number, as the write_http plugin for collectd is sending out timestamps as decimal seconds since the UNIX epoch. 
