### PR TITLE
Handle both timestamp formats from collectd

### DIFF
--- a/lib/cube/server/collectd.js
+++ b/lib/cube/server/collectd.js
@@ -65,7 +65,7 @@ exports.putter = function(putter) {
     });
     request.on("end", function() {
       JSON.parse(content).forEach(function(value) {
-        value.time = Math.round(value.time / 1073741824) * 1000;
+        value.time = (+value.time) * 1000;
         queue.push(value);
       });
       response.writeHead(200);

--- a/lib/cube/server/collectd.js
+++ b/lib/cube/server/collectd.js
@@ -64,8 +64,13 @@ exports.putter = function(putter) {
       content += chunk;
     });
     request.on("end", function() {
+      var now = (new Date).getTime() / 1000;
       JSON.parse(content).forEach(function(value) {
-        value.time = (+value.time) * 1000;
+        // Convert high-res timestamps into seconds since UNIX epoch.
+        if (value.time > now * 10000000) {
+          value.time = Math.round(value.time / 1073741824);
+        }
+        value.time = value.time * 1000;
         queue.push(value);
       });
       response.writeHead(200);


### PR DESCRIPTION
From http://collectd.org/wiki/index.php/High_resolution_time_format

"The high resolution time format is a representation of time used internally to store the time at which a value was collected and the interval in which it is collected."

The `cube/server/collectd` module expects timestamps at this internal resolution, but this behaviour was changed in collectd about 8 months ago [here](https://github.com/collectd/collectd/commit/cf9ac771ade7c5ba75ab13d2b4f2482983994840)

This patch handles both styles of timestamps by first checking if the sent timestamp is extremely large and scaling it down appropriately.
