### PR TITLE
collectd collector should use multiple collections to store data

### DIFF
--- a/lib/cube/collectd.js
+++ b/lib/cube/collectd.js
@@ -40,7 +40,7 @@ exports.putter = function(putter) {
     }
 
     return {
-      type: "collectd",
+      type: "collectd_"+values.plugin,
       time: new Date(+values.time),
       data: root
     };


### PR DESCRIPTION
As collectd reports a lot of different kind of data, it would be better to use a collection per type, like it used to be the case in some previous version of cube.

@mbostock should we maintain a fork just for this line ( :-s ), or would you merge it ?
