### PR TITLE
Adding default start / stop / step to /1.0/metric/get via websocket

### DIFF
--- a/lib/cube/metric.js
+++ b/lib/cube/metric.js
@@ -26,11 +26,11 @@ exports.getter = function(db) {
 
     // Provide default start and stop times for recent events.
     // If the limit is not specified, or too big, use the maximum limit.
-    var stream = !("stop" in request),
+    var stream = (request.stop === undefined) ? true : false,//stream = !("stop" in request),
         limit = !(+request.limit >= limitMax) ? request.limit : limitMax,
         step = +request.step ? +request.step : 1e4,
-        stop = ("stop" in request) ? new Date(request.stop) : new Date(Math.floor(Date.now() / step) * step);
-        start = ("start" in request) ? new Date(request.start) : new Date(0),
+        stop = (request.stop !== undefined) ? new Date(request.stop) : new Date(Math.floor(Date.now() / step) * step);
+        start = (request.start !== undefined) ? new Date(request.start) : new Date(0),
         id = request.id;
 
     // If the time between start and stop is too long, then bring the start time

--- a/lib/cube/metric.js
+++ b/lib/cube/metric.js
@@ -4,45 +4,40 @@ var parser = require("./metric-expression"),
     tiers = require("./tiers"),
     types = require("./types"),
     reduces = require("./reduces"),
-    event = require("./event");
+    event = require("./event"),
+    util = require("util");
 
 var metric_fields = {v: 1},
     metric_options = {sort: {"_id.t": 1}, batchSize: 1000},
     event_options = {sort: {t: 1}, batchSize: 1000},
     limitMax = 1e4;
 
+var streamInterval = 1000;
+
 // Query for metrics.
 exports.getter = function(db) {
   var collection = types(db),
       Double = db.bson_serializer.Double,
       queueByName = {},
-      meta = event.putter(db);
+      meta = event.putter(db),
+      streamsBySource = {};
 
   function getter(request, callback) {
 
-    var limit = +request.limit,
-        step = +request.step;
-
     // Provide default start and stop times for recent events.
     // If the limit is not specified, or too big, use the maximum limit.
-    if (!(step)) step = 1e4;
-    if (!("stop" in request)) request.stop = Math.floor(Date.now() / step) * step;
-    if (!("start" in request)) request.start = 0;
-    if (!(limit <= limitMax)) limit = limitMax;  
+    var stream = !("stop" in request),
+        limit = !(+request.limit >= limitMax) ? request.limit : limitMax,
+        step = +request.step ? +request.step : 1e4,
+        stop = ("stop" in request) ? new Date(request.stop) : new Date(Math.floor(Date.now() / step) * step);
+        start = ("start" in request) ? new Date(request.start) : new Date(0),
+        id = request.id;
 
     // If the time between start and stop is too long, then bring the start time
     // forward so that only the most recent results are returned. This is only
     // approximate in the case of months, but why would you want to return
     // exactly ten thousand months? Don't rely on exact limits!
-    var start = new Date(request.start),
-        stop = new Date(request.stop),
-        id = request.id;
-    if ((stop - start) / step > limit) start = new Date(stop - step * limit); 
-
-    // Validate the dates.
-    // edit: not needed anymore
-    //if (isNaN(start)) return callback({error: "invalid start"}), -1;
-    //if (isNaN(stop)) return callback({error: "invalid stop"}), -1;
+    if ((stop - start) / step > limit) start = new Date(stop - step * limit);
 
     // Parse the expression.
     var expression;
@@ -52,16 +47,98 @@ exports.getter = function(db) {
       return callback({error: "invalid expression"}), -1;
     }
 
+    // Copy any expression filters into the query object.
+    var filter = {t: {$gte: start, $lt: stop}};
+    expression.filter(filter);
+
     // Round start and stop to the appropriate time step.
     var tier = tiers[step];
     if (!tier) return callback({error: "invalid step"}), -1;
     start = tier.floor(start);
     stop = tier.ceil(stop);
 
-    // Compute the request metric!
-    measure(expression, start, stop, tier, "id" in request
+    // For streaming queries, share streams for efficient polling.
+    if (stream) {
+
+      if (!streamsBySource[expression.source])
+        streamsBySource[expression.source] = [];
+
+      var streams = streamsBySource[expression.source][tier.key];
+
+      // If there is an existing stream to attach to, backfill the initial set
+      // of results to catch the client up to the stream. Add the new callback
+      // to a queue, so that when the shared stream finishes its current poll,
+      // it begins notifying the new client. Note that we don't pass the null
+      // (end terminator) to the callback, because more results are to come!
+      if (streams) {
+
+        filter.t.$lt = streams.time;
+        streams.waiting.push(callback);
+        measure(expression, start, stop, tier, "id" in request
         ? function(time, value) { callback({time: time, value: value, id: id}); }
         : function(time, value) { callback({time: time, value: value}); });
+      }
+
+      // Otherwise, we're creating a new stream, so we're responsible for
+      // starting the polling loop. This means notifying active callbacks,
+      // detecting when active callbacks are closed, advancing the time window,
+      // and moving waiting clients to active clients.
+      else {
+        streams = streamsBySource[expression.source][tier.key] = {time: stop, waiting: [], active: [callback]};
+        (function poll() {
+
+          poll.triggered = false;
+
+          var callbackFunction = function(metric) {
+
+            //util.log('processed : ' + JSON.stringify(metric));
+
+
+            // If there's a value in metric, send it to all active, open clients.
+            if (metric.value !== undefined) {
+              streams.active.forEach(function(callback) {
+                // TODO
+                if (!callback.closed) callback(metric);
+              });
+            }
+
+            // If poll isn't triggered, that's mean we have to do it.
+            // merge the waiting callbacks into the active callbacks. Advance
+            // the time range, and set a timeout for the next poll.
+
+            if (!poll.triggered) {
+              streams.active = streams.active.concat(streams.waiting).filter(open);
+              streams.waiting = [];
+
+              // If no clients remain, then it's safe to delete the shared
+              // stream, and we'll no longer be responsible for polling.
+              if (!streams.active.length) {
+                delete streamsBySource[expression.source][tier.key];
+                if (streamsBySource[expression.source].length === 0)
+                  delete streamsBySource[expression.source];
+                return;
+              }
+
+              filter.t.$gte = filter.t.$lt;
+              filter.t.$lt = streams.time = tier.ceil(new Date(Date.now()));
+              setTimeout(poll, tier.key);
+              poll.triggered = true;
+            }
+
+          };
+
+          measure(expression, filter.t.$gte, filter.t.$lt, tier, "id" in request
+            ? function(time, value) { callbackFunction({time: time, value: value, id: id}); }
+            : function(time, value) { callbackFunction({time: time, value: value}); });
+        })();
+      }
+    } else {
+
+    // Compute the request metric!
+      measure(expression, start, stop, tier, "id" in request
+      ? function(time, value) { callback({time: time, value: value, id: id}); }
+      : function(time, value) { callback({time: time, value: value}); });
+    }
   }
 
   // Computes the metric for the given expression for the time interval from
@@ -256,9 +333,17 @@ exports.getter = function(db) {
     });
   }
 
+  getter.close = function(callback) {
+    callback.closed = true;
+  };
+
   return getter;
 };
 
 function handle(error) {
   if (error) throw error;
+}
+
+function open(callback) {
+  return !callback.closed;
 }

--- a/lib/cube/metric.js
+++ b/lib/cube/metric.js
@@ -8,7 +8,8 @@ var parser = require("./metric-expression"),
 
 var metric_fields = {v: 1},
     metric_options = {sort: {"_id.t": 1}, batchSize: 1000},
-    event_options = {sort: {t: 1}, batchSize: 1000};
+    event_options = {sort: {t: 1}, batchSize: 1000},
+    limitMax = 1e4;
 
 // Query for metrics.
 exports.getter = function(db) {
@@ -18,13 +19,30 @@ exports.getter = function(db) {
       meta = event.putter(db);
 
   function getter(request, callback) {
+
+    var limit = +request.limit,
+        step = +request.step;
+
+    // Provide default start and stop times for recent events.
+    // If the limit is not specified, or too big, use the maximum limit.
+    if (!(step)) step = 1e4;
+    if (!("stop" in request)) request.stop = Math.floor(Date.now() / step) * step;
+    if (!("start" in request)) request.start = 0;
+    if (!(limit <= limitMax)) limit = limitMax;  
+
+    // If the time between start and stop is too long, then bring the start time
+    // forward so that only the most recent results are returned. This is only
+    // approximate in the case of months, but why would you want to return
+    // exactly ten thousand months? Don't rely on exact limits!
     var start = new Date(request.start),
         stop = new Date(request.stop),
         id = request.id;
+    if ((stop - start) / step > limit) start = new Date(stop - step * limit); 
 
     // Validate the dates.
-    if (isNaN(start)) return callback({error: "invalid start"}), -1;
-    if (isNaN(stop)) return callback({error: "invalid stop"}), -1;
+    // edit: not needed anymore
+    //if (isNaN(start)) return callback({error: "invalid start"}), -1;
+    //if (isNaN(stop)) return callback({error: "invalid stop"}), -1;
 
     // Parse the expression.
     var expression;
@@ -35,7 +53,7 @@ exports.getter = function(db) {
     }
 
     // Round start and stop to the appropriate time step.
-    var tier = tiers[+request.step];
+    var tier = tiers[step];
     if (!tier) return callback({error: "invalid step"}), -1;
     start = tier.floor(start);
     stop = tier.ceil(stop);


### PR DESCRIPTION
I quickly fixed the issue I drop a few hours ago :
https://github.com/square/cube/issues/72

The fix might not be the best solution, but it worked for me.
