### PR TITLE
Serve static dir from correct location

### DIFF
--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -37,7 +37,7 @@ module.exports = function(options) {
   var server = {},
       primary = http.createServer(),
       secondary = websprocket.createServer(),
-      file = new static.Server("static"),
+      file = new static.Server(__dirname + "/../../static"),
       meta,
       endpoints = {ws: [], http: []},
       mongo = new mongodb.Server(options["mongo-host"], options["mongo-port"], server_options),


### PR DESCRIPTION
If you ran cube from a dir other than the root dir, then the path to the
static dir was not correct.
