### PR TITLE
Use ObjectID timestamps instead of dedicated field

### DIFF
--- a/lib/cube/event.js
+++ b/lib/cube/event.js
@@ -14,7 +14,7 @@ var type_re = /^[a-z][a-zA-Z0-9_]+$/,
     metric_options = {capped: true, size: 1e7, autoIndexId: true};
 
 // When streaming events, we should allow a delay for events to arrive, or else
-// we risk skipping events that arrive after their event.time. This delay can be
+// we risk skipping events that arrive after their event time. This delay can be
 // customized by specifying a `delay` property as part of the request.
 var streamDelayDefault = 5000,
     streamInterval = 1000;
@@ -36,9 +36,10 @@ exports.putter = function(db) {
     if (!type_re.test(type)) return callback({error: "invalid type"}), -1;
     if (isNaN(time)) return callback({error: "invalid time"}), -1;
 
-    // If an id is specified, promote it to Mongo's primary key.
-    var event = {t: time, d: request.data};
-    if ("id" in request) event._id = request.id;
+    // Generate a Mongo ObjectID based on the event time.
+    // If an id is specified, add it to the event data.
+    var event = {_id: new ObjectID(time/1000), d: request.data};
+    if ("id" in request) event.d.id = request.id;
 
     // If this is a known event type, save immediately.
     if (type in knownByType) return save(type, event);
@@ -62,8 +63,8 @@ exports.putter = function(db) {
       var events = collection(type).events;
       if (names.length) return saveEvents();
 
-      // Events are indexed by time.
-      events.ensureIndex({"t": 1}, handle);
+      // Ensure uniqueness of id.
+      events.ensureIndex({"d.id": 1}, {unique: true, sparse: true},  handle);
 
       // Create a capped collection for metrics. Three indexes are required: one
       // for finding metrics, one (_id) for updating, and one for invalidation.
@@ -101,7 +102,7 @@ exports.putter = function(db) {
   // The times are kept in sorted order for bisection.
   function queueInvalidation(type, event) {
     var timesToInvalidateByTier = timesToInvalidateByTierByType[type],
-        time = event.t;
+        time = event._id.getTimestamp();
     if (timesToInvalidateByTier) {
       for (var tier in tiers) {
         var tierTimes = timesToInvalidateByTier[tier],
@@ -154,6 +155,10 @@ exports.getter = function(db) {
     if (isNaN(start)) return callback({error: "invalid start"}), -1;
     if (isNaN(stop)) return callback({error: "invalid stop"}), -1;
 
+    // Convert them to ObjectIDs.
+    start = ObjectID.createFromTime(start/1000);
+    stop = ObjectID.createFromTime(stop/1000);
+
     // Parse the expression.
     var expression;
     try {
@@ -163,15 +168,15 @@ exports.getter = function(db) {
     }
 
     // Set an optional limit on the number of events to return.
-    var options = {sort: {t: -1}, batchSize: 1000};
+    var options = {sort: {_id: -1}, batchSize: 1000};
     if ("limit" in request) options.limit = +request.limit;
 
     // Copy any expression filters into the query object.
-    var filter = {t: {$gte: start, $lt: stop}};
+    var filter = {_id: {$gte: start, $lt: stop}};
     expression.filter(filter);
 
     // Request any needed fields.
-    var fields = {t: 1};
+    var fields = {_id:1};
     expression.fields(fields);
 
     // Query for the desired events.
@@ -188,7 +193,7 @@ exports.getter = function(db) {
           handle(error);
 
           // A null event indicates that there are no more results.
-          if (event) callback({id: event._id instanceof ObjectID ? undefined : event._id, time: event.t, data: event.d});
+          if (event) callback({id: event._id instanceof ObjectID ? undefined : event._id, time: event._id.getTimestamp(), data: event.d});
           else callback(null);
         });
       });
@@ -204,7 +209,7 @@ exports.getter = function(db) {
       // it begins notifying the new client. Note that we don't pass the null
       // (end terminator) to the callback, because more results are to come!
       if (streams) {
-        filter.t.$lt = streams.time;
+        filter._id.$lt = streams.time;
         streams.waiting.push(callback);
         query(function(event) { if (event) callback(event); });
       }
@@ -239,8 +244,8 @@ exports.getter = function(db) {
                 return;
               }
 
-              filter.t.$gte = streams.time;
-              filter.t.$lt = streams.time = new Date(Date.now() - delay);
+              filter._id.$gte = streams.time;
+              filter._id.$lt = streams.time = new ObjectID((Date.now() - delay)/1000);
               setTimeout(poll, streamInterval);
             }
           });

--- a/lib/cube/metric.js
+++ b/lib/cube/metric.js
@@ -4,11 +4,13 @@ var parser = require("./metric-expression"),
     tiers = require("./tiers"),
     types = require("./types"),
     reduces = require("./reduces"),
-    event = require("./event");
+    event = require("./event"),
+    mongodb = require("mongodb"),
+    ObjectID = mongodb.ObjectID;
 
 var metric_fields = {v: 1},
     metric_options = {sort: {"_id.t": 1}, batchSize: 1000},
-    event_options = {sort: {t: 1}, batchSize: 1000};
+    event_options = {sort: {_id: 1}, batchSize: 1000};
 
 // Query for metrics.
 exports.getter = function(db) {
@@ -114,8 +116,8 @@ exports.getter = function(db) {
         type = collection(name),
         map = expression.value,
         reduce = reduces[expression.reduce],
-        filter = {t: {}},
-        fields = {t: 1};
+        filter = {_id: {}},
+        fields = {_id: 1};
 
     // Copy any expression filters into the query object.
     expression.filter(filter);
@@ -174,15 +176,15 @@ exports.getter = function(db) {
       // the order in which rows are returned from the database. Thus, we know
       // when we've seen all of the events for a given time interval.
       function computeFlat(start, stop) {
-        filter.t.$gte = start;
-        filter.t.$lt = stop;
+        filter._id.$gte = ObjectID.createFromTime(start/1000);
+        filter._id.$lt = ObjectID.createFromTime(stop/1000);
         type.events.find(filter, fields, event_options, function(error, cursor) {
           handle(error);
           var time = start, values = [];
           cursor.each(function(error, row) {
             handle(error);
             if (row) {
-              var then = tier.floor(row.t);
+              var then = tier.floor(row._id.getTimestamp());
               if (time < then) {
                 save(time, values.length ? reduce(values) : reduce.empty);
                 while ((time = tier.step(time)) < then) save(time, reduce.empty);


### PR DESCRIPTION
Hello Mike,

This is my attempt to solve issue #16. Tests are good on my side except `test.js` which was already failing.
I've followed your will to keep the `id` in `d` with a sparse unique index.

I haven't run any performance comparison but I'd be interested to know if you give it a shot.
