### PR TITLE
Unified logging and meta-cubifying of internal progress

### DIFF
--- a/lib/cube/collector.js
+++ b/lib/cube/collector.js
@@ -1,11 +1,21 @@
-var endpoint = require("./endpoint");
-
 //
+// collector -- listen for incoming metrics
+//
+
+var endpoint = require("./endpoint"),
+    metalog  = require('./metalog');
+
 var headers = {
   "Content-Type": "application/json",
   "Access-Control-Allow-Origin": "*"
 };
 
+// Register Collector listeners at their appropriate paths:
+//
+// * putter,   handles each isolated event -- see event.js
+// * poster,   an HTTP listener -- see below
+// * collectd, a collectd listener -- see collectd.js
+//
 exports.register = function(db, endpoints) {
   var putter = require("./event").putter(db),
       poster = post(putter);
@@ -26,6 +36,13 @@ exports.register = function(db, endpoints) {
   endpoints.udp = putter;
 };
 
+//
+// Construct HTTP listener
+//
+// * aggregate content into a complete request
+// * JSON-parse the request body
+// * dispatch each metric as an event to the putter
+//
 function post(putter) {
   return function(request, response) {
     var content = "";
@@ -36,6 +53,7 @@ function post(putter) {
       try {
         JSON.parse(content).forEach(putter);
       } catch (e) {
+        metalog.event("cube_request", { at: "c", res: "collector_post_error", error: e, code: 400 });
         response.writeHead(400, headers);
         response.end(JSON.stringify({error: e.toString()}));
         return;

--- a/lib/cube/emitter.js
+++ b/lib/cube/emitter.js
@@ -1,3 +1,9 @@
+//
+// emitter - writes events to the collector.
+//
+// URL's scheme determines UDP, websocket or HTTP emitter, as appropriate.
+//
+
 var util = require("util"),
     url = require("url"),
     http = require("./emitter-http"),

--- a/lib/cube/endpoint.js
+++ b/lib/cube/endpoint.js
@@ -1,3 +1,12 @@
+//
+// endpoint -- router for requests.
+//
+// specify
+// * optional HTTP method ("GET", "POST", etc)
+// * path, a String or RegExp
+// * dispatch, a callback to invoke
+//
+
 module.exports = function(method, path, dispatch) {
   return {
     match: arguments.length < 3

--- a/lib/cube/event.js
+++ b/lib/cube/event.js
@@ -6,6 +6,7 @@ var mongodb = require("mongodb"),
     tiers = require("./tiers"),
     types = require("./types"),
     bisect = require("./bisect"),
+    metalog = require("./metalog"),
     ObjectID = mongodb.ObjectID;
 
 var type_re = /^[a-z][a-zA-Z0-9_]+$/,
@@ -22,6 +23,14 @@ var streamDelayDefault = 5000,
 // How frequently to invalidate metrics after receiving events.
 var invalidateInterval = 5000;
 
+// event.putter -- save the event, invalidate any cached metrics impacted by it.
+//
+// @param request --
+//   - id,   a unique ID (optional). If included, it will be used as the Mongo record's primary key -- if the collector receives that event multiple times, it will only be stored once. If omitted, Mongo will generate a unique ID for you.
+//   - time, timestamp for the event (a date-formatted string)
+//   - type, namespace for the events. A corresponding `foo_events` collection must exist in the DB -- /schema/schema-*.js illustrate how to set up a new event type.
+//   - data, the event's payload
+//
 exports.putter = function(db) {
   var collection = types(db),
       knownByType = {},
@@ -92,6 +101,7 @@ exports.putter = function(db) {
   // likelihood of a race condition between when the events are read by the
   // evaluator and when the newly-computed metrics are saved.
   function save(type, event) {
+    // metalog.info("cube_request", { is: "ev", at: "save", type: type, event: event });
     collection(type).events.save(event, handle);
     queueInvalidation(type, event);
   }
@@ -125,6 +135,7 @@ exports.putter = function(db) {
     for (var type in timesToInvalidateByTierByType) {
       var metrics = collection(type).metrics,
           timesToInvalidateByTier = timesToInvalidateByTierByType[type];
+      metalog.info("cube_compute", { is: "flush", type: type });
       for (var tier in tiers) {
         metrics.update({
           i: false,
@@ -140,6 +151,18 @@ exports.putter = function(db) {
   return putter;
 };
 
+//
+// event.getter - subscribe to event type
+//
+// if `stop` is not given, does a streaming response, polling for results every
+// `streamDelay` (5 seconds).
+//
+// if `stop` is given, return events from the given interval
+//
+// * convert the request expression and filters into a MongoDB-ready query
+// * Issue the query;
+// * if streaming, register the query to be run at a regular interval
+//
 exports.getter = function(db) {
   var collection = types(db),
       streamsBySource = {};
@@ -253,6 +276,9 @@ exports.getter = function(db) {
   }
 
   getter.close = function(callback) {
+    // results or periodic calls may have already been set in motion, but
+    // trigger in the future; this ensures they quit listening and drop further
+    // results on the floor.
     callback.closed = true;
   };
 

--- a/lib/cube/index.js
+++ b/lib/cube/index.js
@@ -1,3 +1,4 @@
+exports.metalog = require("./metalog");
 exports.emitter = require("./emitter");
 exports.server = require("./server");
 exports.collector = require("./collector");

--- a/lib/cube/metalog.js
+++ b/lib/cube/metalog.js
@@ -1,0 +1,46 @@
+var util  = require("util");
+
+var metalog = {
+  putter:  null,
+  log:     util.log,
+  silent:  function(){ }
+}
+
+// adjust verboseness by reassigning `metalog.loggers.{level}`
+// @example: quiet all logs
+//   metalog.loggers.info = metalog.silent();
+metalog.loggers = {
+  info:  metalog.log,
+  minor: metalog.silent
+}
+
+// if true, cubify `metalog.event`s
+metalog.send_events = true;
+
+// Cubify an event and (optionally) log it. The last parameter specifies the
+// logger -- 'info' (the default), 'minor' or 'silent'.
+metalog.event = function(name, hsh, logger){
+  metalog[logger||"info"](name, hsh);
+  if ((! metalog.send_events) || (! metalog.putter)) return;
+  metalog.putter({ type: name, time: Date.now(), data: hsh });
+};
+
+// Events important enough for the production log file. Does not cubify.
+metalog.info = function(name, hsh){
+  metalog.loggers.info(name + "\t" + JSON.stringify(hsh));
+};
+
+// Debug-level statements; loggers.minor is typically mapped to 'silent'.
+metalog.minor = function(name, hsh){
+  metalog.loggers.minor(name + "\t" + JSON.stringify(hsh));
+};
+
+// Dump the 'util.inspect' view of each argument to the console.
+metalog.inspectify = function(args){
+  args = Array.prototype.slice.call(arguments);
+  args.map(function (arg){
+    util.debug(util.inspect(arg));
+  });
+};
+
+module.exports = metalog;

--- a/lib/cube/metric.js
+++ b/lib/cube/metric.js
@@ -4,7 +4,8 @@ var parser = require("./metric-expression"),
     tiers = require("./tiers"),
     types = require("./types"),
     reduces = require("./reduces"),
-    event = require("./event");
+    event = require("./event"),
+    metalog = require('./metalog');
 
 var metric_fields = {v: 1},
     metric_options = {sort: {"_id.t": 1}, batchSize: 1000},
@@ -14,8 +15,7 @@ var metric_fields = {v: 1},
 exports.getter = function(db) {
   var collection = types(db),
       Double = db.bson_serializer.Double,
-      queueByName = {},
-      meta = event.putter(db);
+      queueByName = {};
 
   function getter(request, callback) {
     var start = new Date(request.start),
@@ -95,13 +95,9 @@ exports.getter = function(db) {
 
           // Record how long it took us to compute as an event!
           var time1 = Date.now();
-          meta({
-            type: "cube_compute",
-            time: time1,
-            data: {
-              expression: expression.source,
-              ms: time1 - time0
-            }
+          metalog.event("cube_compute", {
+            expression: expression.source,
+            ms: time1 - time0
           });
         }
       });
@@ -200,8 +196,8 @@ exports.getter = function(db) {
 
       function save(time, value) {
         callback(time, value);
-        if (value) {
-          type.metrics.save({
+        if (! value) return;
+        var metric = {
             _id: {
               e: expression.source,
               l: tier.key,
@@ -209,8 +205,9 @@ exports.getter = function(db) {
             },
             i: false,
             v: new Double(value)
-          }, handle);
-        }
+        };
+        metalog.info('cube_compute', {is: 'metric_save', metric: metric });
+        type.metrics.save(metric, handle);
       }
     }
   }

--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -1,3 +1,16 @@
+// Server -- generic HTTP, UDP and websockets server
+//
+// Used by the collector to accept new events via HTTP or websockets
+// Used by the evaluator to serve pages over HTTP, and the continuously-updating
+//   metrics stream over websockets
+//
+// holds
+// * the primary and secondary websockets connections
+// * the HTTP listener connection
+// * the MongoDB connection
+// * the UDP listener connection
+//
+
 var util = require("util"),
     url = require("url"),
     http = require("http"),
@@ -5,7 +18,8 @@ var util = require("util"),
     websocket = require("websocket"),
     websprocket = require("websocket-server"),
     static = require("node-static"),
-    mongodb = require("mongodb");
+    mongodb = require("mongodb"),
+    metalog = require("./metalog");
 
 // Don't crash on errors.
 process.on("uncaughtException", function(error) {
@@ -38,7 +52,6 @@ module.exports = function(options) {
       primary = http.createServer(),
       secondary = websprocket.createServer(),
       file = new static.Server("static"),
-      meta,
       endpoints = {ws: [], http: []},
       mongo = new mongodb.Server(options["mongo-host"], options["mongo-port"], server_options),
       db = new mongodb.Db(options["mongo-database"], mongo, db_options),
@@ -88,20 +101,10 @@ module.exports = function(options) {
           e.dispatch(JSON.parse(message.utf8Data || message), callback);
         });
 
-        meta({
-          type: "cube_request",
-          time: Date.now(),
-          data: {
-            ip: connection.remoteAddress,
-            path: request.url,
-            method: "WebSocket"
-          }
-        });
-
+        metalog.event('cube_request', { is: 'ws', method: "WebSocket", ip: connection.remoteAddress, path: request.url}, 'minor');
         return;
       }
     }
-
     connection.close();
   }
 
@@ -113,17 +116,7 @@ module.exports = function(options) {
     for (var i = -1, n = endpoints.http.length, e; ++i < n;) {
       if ((e = endpoints.http[i]).match(u.pathname, request.method)) {
         e.dispatch(request, response);
-
-        meta({
-          type: "cube_request",
-          time: Date.now(),
-          data: {
-            ip: request.connection.remoteAddress,
-            path: u.pathname,
-            method: request.method
-          }
-        });
-
+        metalog.event('cube_request', { method: request.method, ip: request.connection.remoteAddress, path: u.pathname });
         return;
       }
     }
@@ -132,6 +125,7 @@ module.exports = function(options) {
     request.on("end", function() {
       file.serve(request, response, function(error) {
         if (error) {
+          metalog.event('cube_request', { is: 'failed', msg: error, code: error.status, ip: request.connection.remoteAddress, path: u.pathname });
           response.writeHead(error.status, {"Content-Type": "text/plain"});
           response.end(error.status + "");
         }
@@ -141,11 +135,12 @@ module.exports = function(options) {
 
   server.start = function() {
     // Connect to mongodb.
-    util.log("starting mongodb client");
+    mongo_password = options["mongo-password"]; delete options["mongo-password"];
+    metalog.info('cube_life', {is: 'mongo_connect', options: options });
     db.open(function(error) {
       if (error) throw error;
       if (options["mongo-username"] == null) return ready();
-      db.authenticate(options["mongo-username"], options["mongo-password"], function(error, success) {
+      db.authenticate(options["mongo-username"], mongo_password, function(error, success) {
         if (error) throw error;
         if (!success) throw new Error("authentication failed");
         ready();
@@ -155,11 +150,11 @@ module.exports = function(options) {
     // Start the server!
     function ready() {
       server.register(db, endpoints);
-      meta = require("./event").putter(db);
-      util.log("starting http server on port " + options["http-port"]);
+      metalog.putter = require("./event").putter(db);
+      metalog.event("cube_life", { is: 'start_http', port: options["http-port"] });
       primary.listen(options["http-port"]);
       if (endpoints.udp) {
-        util.log("starting udp server on port " + options["udp-port"]);
+        metalog.event("cube_life", { is: 'start_udp', port: options["udp-port"] });
         var udp = dgram.createSocket("udp4");
         udp.on("message", function(message) {
           endpoints.udp(JSON.parse(message.toString("utf8")), ignore);

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
   "repository": {"type": "git", "url": "http://github.com/square/cube.git"},
   "main": "./lib/cube",
   "dependencies": {
-    "mongodb": "1.0.1",
-    "node-static": "0.5.9",
-    "pegjs": "0.6.2",
-    "vows": "0.5.11",
-    "websocket": "1.0.3",
+    "mongodb":          "1.0.1",
+    "node-static":      "0.5.9",
+    "pegjs":            "0.6.2",
+    "vows":             "0.5.11",
+    "node-gyp":         "0.6.8",
+    "websocket":        "1.0.3",
     "websocket-server": "1.4.04"
   }
 }

--- a/test/metalog-test.js
+++ b/test/metalog-test.js
@@ -1,0 +1,122 @@
+var vows           = require("vows"),
+    assert         = require("assert"),
+    test           = require('./test');
+
+var suite = vows.describe("metalog");
+
+suite.with_log = function(batch){
+  suite.addBatch({
+    '':{
+      topic: function(){
+        var metalog = require("../lib/cube/metalog");
+        var logged = this.logged = { infoed: [], minored: [], putted: [] };
+        this.original = { send_events: metalog.send_events, putter: metalog.putter, info: metalog.loggers.info, minor: metalog.loggers.minor };
+        metalog.send_events   = true;
+        metalog.loggers.info  = function(line){ logged.infoed.push(line);  };
+        metalog.loggers.minor = function(line){ logged.minored.push(line); };
+        metalog.putter        = function(line){ logged.putted.push(line);  };
+        return metalog;
+      },
+      metalog: batch,
+      teardown: function(metalog){
+        metalog.loggers.info  = this.original.info;
+        metalog.loggers.minor = this.original.minor;
+        metalog.putter        = this.original.putter;
+      }
+    }
+  });
+  return suite;
+}
+
+suite.with_log({
+  '.info': {
+    'logs record to metalog.logers.info': function(metalog){
+      metalog.info('reactor_level', { criticality: 7, cores: 'leaking' });
+      assert.equal(this.logged.infoed.pop(), 'reactor_level\t{"criticality":7,"cores":"leaking"}');
+      assert.deepEqual(this.logged, { infoed: [], minored: [], putted: [] });
+    }
+  }
+}).with_log({
+  '.minor': {
+    'logs record to metalog.loggers.minor': function(metalog){
+      metalog.minor('reactor_level', { modacity: 3 });
+      assert.equal(this.logged.minored.pop(), 'reactor_level\t{"modacity":3}');
+      assert.deepEqual(this.logged, { infoed: [], minored: [], putted: [] });
+    }
+  }
+}).with_log({
+  '.event': {
+    'with send_events=true': {
+      topic: function(metalog){
+        metalog.send_events = true;
+        metalog.event('reactor_level', { criticality: 9, hemiconducers: 'relucting' });
+        return metalog;
+      },
+      'logs record to metalog.info by default': function(metalog){
+        assert.equal(this.logged.infoed.pop(), 'reactor_level\t{"criticality":9,"hemiconducers":"relucting"}');
+      },
+      'writes an event to cube itself': function(metalog){
+        event = this.logged.putted.pop();
+        event.time = 'whatever';
+        assert.deepEqual(event, {
+          data: { hemiconducers: 'relucting', criticality: 9 },
+          type: 'reactor_level',
+          time: 'whatever'
+        });
+      }
+    }
+  }
+}).with_log({
+  '.event': {
+    'with send_events=false': {
+      topic: function(metalog){
+        metalog.send_events = false;
+        metalog.event('reactor_level', { criticality: 10, hemiconducers: 'fremulating' });
+        return metalog;
+      },
+      'logs record to metalog.loggers.info': function(metalog){
+        assert.equal(this.logged.infoed.pop(), 'reactor_level\t{"criticality":10,"hemiconducers":"fremulating"}');
+      },
+      'does not write an event to cube': function(metalog){
+        assert.deepEqual(this.logged, { infoed: [], minored: [], putted: [] });
+      }
+    }
+  }
+}).with_log({
+  '.event': {
+    'last parameter overrides log target': {
+      topic: function(metalog) {
+        metalog.send_events = true;
+        metalog.event('reactor_level', { criticality: 3, hemiconducers: 'cromulent' }, 'minor');
+        metalog.event('reactor_level', { criticality: 2, hemiconducers: 'whispery'  }, 'silent');
+        return metalog;
+      },
+      '': function(metalog){
+        assert.equal(this.logged.minored.pop(), 'reactor_level\t{"criticality":3,"hemiconducers":"cromulent"}');
+        assert.equal(this.logged.putted.pop().data.criticality, 2);
+        assert.equal(this.logged.putted.pop().data.criticality, 3);
+        assert.deepEqual(this.logged, { infoed: [], minored: [], putted: [] });
+      }
+    }
+  }
+});
+
+function dummy_logger(arg){};
+
+suite.addBatch({
+  'metalog':{
+    topic: function(){ return require("../lib/cube/metalog"); },
+    '': {
+      'loggers persist across factory invocation': function(metalog){
+        metalog.orig_minor    = metalog.loggers.minor;
+        metalog.loggers.minor = dummy_logger;
+        var ml2 = require("../lib/cube/metalog");
+        assert.deepEqual(metalog, ml2);
+        assert.deepEqual(metalog.loggers.minor,    dummy_logger);
+        assert.notDeepEqual(metalog.loggers.minor, metalog.orig_minor);
+      },
+      teardown: function(metalog){ metalog.loggers.minor = metalog.orig_minor; }
+    }
+  }});
+
+suite.export(module);

--- a/test/metric-test.js
+++ b/test/metric-test.js
@@ -4,6 +4,11 @@ var vows = require("vows"),
     event = require("../lib/cube/event"),
     metric = require("../lib/cube/metric");
 
+// as a hack to get updates to settle, we need to insert delays
+// if you see funny heisen-errors in the metrics tests try bumping these
+var step_testing_delay  = 250,
+    batch_testing_delay = 500;
+
 var suite = vows.describe("metric");
 
 var steps = {
@@ -34,7 +39,7 @@ suite.addBatch(test.batch({
       });
     }
 
-    setTimeout(function() { callback(null, getter); }, 500);
+    setTimeout(function() { callback(null, getter); }, batch_testing_delay);
   },
 
   "unary expression": metricTest({
@@ -71,7 +76,7 @@ suite.addBatch(test.batch({
     }
   ),
 
-  "compound expression": metricTest({
+  "compound expression (sometimes fails due to race condition?)": metricTest({
       expression: "max(test(i)) - min(test(i))",
       start: "2011-07-17T23:47:00.000Z",
       stop: "2011-07-18T00:50:00.000Z",
@@ -150,7 +155,7 @@ function metricTest(request, expected) {
               actual.push(response);
             }
           });
-        }, depth * 250);
+        }, depth * step_testing_delay);
       }
     };
 

--- a/test/test.js
+++ b/test/test.js
@@ -32,5 +32,4 @@ exports.request = function(options, data) {
 // Disable logging for tests.
 metalog.loggers.info  = metalog.silent;
 metalog.loggers.minor = metalog.silent;
-util.log = function() {};
 metalog.send_events = false;

--- a/test/test.js
+++ b/test/test.js
@@ -1,37 +1,13 @@
 var mongodb = require("mongodb"),
-    assert = require("assert"),
-    util = require("util"),
-    http = require("http");
+    assert  = require("assert"),
+    util    = require("util"),
+    metalog = require("../lib/cube/metalog"),
+    test_db = require("./test_db"),
+    http    = require("http");
 
 exports.port = 1083;
 
-exports.batch = function(batch) {
-  return {
-    "": {
-      topic: function() {
-        var client = new mongodb.Server("localhost", 27017);
-            db = new mongodb.Db("cube_test", client),
-            cb = this.callback;
-        db.open(function(error) {
-          var collectionsRemaining = 2;
-          db.dropCollection("test_events", collectionReady);
-          db.dropCollection("test_metrics", collectionReady);
-          function collectionReady() {
-            if (!--collectionsRemaining) {
-              cb(null, {client: client, db: db});
-            }
-          }
-        });
-      },
-      "": batch,
-      teardown: function(test) {
-        if (test.client.isConnected()) {
-          test.client.close();
-        }
-      }
-    }
-  };
-};
+exports.batch = test_db.batch;
 
 exports.request = function(options, data) {
   return function() {
@@ -54,4 +30,7 @@ exports.request = function(options, data) {
 };
 
 // Disable logging for tests.
+metalog.loggers.info  = metalog.silent;
+metalog.loggers.minor = metalog.silent;
 util.log = function() {};
+metalog.send_events = false;

--- a/test/test_db.js
+++ b/test/test_db.js
@@ -1,0 +1,75 @@
+var mongodb        = require("mongodb"),
+    util           = require("util"),
+    metalog        = require("../lib/cube/metalog");
+
+var test_db = { };
+
+var test_collections = ["test_users", "test_events", "test_metrics"];
+
+var options = exports.options = {
+  "mongo-host":     "localhost",
+  "mongo-port":     27017,
+  "mongo-database": "cube_test"
+};
+
+exports.using_objects = function (clxn_name, test_objects){
+  metalog.minor('cube_testdb', {state: 'loading test objects', test_objects: test_objects });
+  return function(tdb){
+    var that = this;
+    tdb.db.collection(clxn_name, function(err, clxn){
+      if (err) throw(err);
+      that[clxn_name] = clxn;
+      clxn.remove({ dummy: true }, {safe: true}, function(){
+        clxn.insert(test_objects, { safe: true }, function(){
+          that.callback(null);
+        }); });
+    });
+  };
+};
+
+exports.batch = function(batch) {
+  return {
+    "": {
+      topic: function() {
+        connect();
+        setup_db(this.callback);
+      },
+      "": batch,
+      teardown: function(test) {
+        if (test.client.isConnected()) {
+          process.nextTick(function(){ test.client.close(); });
+        };
+      }
+    }
+  };
+};
+
+//
+// db methods
+//
+
+function setup_db(cb){
+  drop_collections(cb);
+}
+
+function connect(){
+  metalog.minor('cube_testdb', { state: 'connecting to db', options: options });
+  test_db.options = options;
+  test_db.client  = new mongodb.Server(options["mongo-host"], options["mongo-port"], {auto_reconnect: true});
+  test_db.db      = new mongodb.Db(options["mongo-database"], test_db.client, {});
+}
+
+function drop_collections(cb){
+  metalog.minor('cube_testdb', { state: 'dropping test collections', collections: test_collections });
+  test_db.db.open(function(error) {
+    var collectionsRemaining = test_collections.length;
+    test_collections.forEach(function(collection_name){
+      test_db.db.dropCollection(collection_name,  collectionReady);
+    });
+    function collectionReady() {
+      if (!--collectionsRemaining) {
+        cb(null, test_db);
+      }
+    }
+  });
+}


### PR DESCRIPTION
Cleaned up and standardized the `util.log` statements and the `meta` statements into a metalog module:
- `metalog.info('foo', {...})` for progress recording -- sent to log by default
- `metalog.minor('foo', {...})` for verbose recording -- sent nowhere by default
- `metalog.event('foo', {...})` cubifies the event and sends it to info
  - `metalog.event('foo', {...}, 'silent')` to cubify but not log
- retarget log statements by reassigning the appropriate `metalog.loggers`: for example, say `metalog.loggers.minor = metalog.log` to log minor events (be verbose), or `metalog.loggers.info  = metalog.silent` to quash logging.
