### PR TITLE
Pluggable authentication: allow_all, or use a cookie to check user record in DB

### DIFF
--- a/bin/collector-config.js
+++ b/bin/collector-config.js
@@ -6,5 +6,6 @@ module.exports = {
   "mongo-username": null,
   "mongo-password": null,
   "http-port": 1080,
-  "udp-port": 1180
+  "udp-port": 1180,
+  "authenticator": "allow_all"
 };

--- a/bin/evaluator-config.js
+++ b/bin/evaluator-config.js
@@ -5,5 +5,6 @@ module.exports = {
   "mongo-database": "cube_development",
   "mongo-username": null,
   "mongo-password": null,
-  "http-port": 1081
+  "http-port": 1081,
+  "authenticator": "allow_all"
 };

--- a/lib/cube/authentication.js
+++ b/lib/cube/authentication.js
@@ -1,0 +1,114 @@
+//
+// authentication -- authenticate user identities and authorize their action
+//
+// Call an authenticator with the request and ok/no callbacks:
+// * if authentication succeeds, a permissions record is attached to the request
+//   object as `request.authorized`, and sent as the callback parameter.
+// * if authentication fails, the callback is called with a short string
+//   describing the reason.
+//
+// The authenticators include:
+// * allow_all -- uniformly authenticates all requests, authorizing all to write
+// * read_only -- uniformly authenticates all requests, authorizing none to write
+// * mongo_cookie -- validates bcrypt'ed token in cookie with user record in db.
+//
+// This module does not provide any means for creating user tokens; do this in
+// your front-end app.
+//
+
+var mongodb  = require("mongodb"),
+    cookies  = require("cookies"),
+    bcrypt   = require("bcrypt"),
+    metalog  = require('./metalog')
+    ;
+
+var authentication = {};
+
+authentication.authenticator = function(strategy, db, options){
+  metalog.minor('cube_auth', { strategy: strategy });
+  return authentication[strategy](db, options);
+}
+
+authentication.allow_all = function(){
+  function check(request, auth_ok, auth_no) {
+    metalog.event('cube_auth', { authenticator: 'allow_all', path: request.url }, 'minor');
+    request.authorized = { admin: true };
+    return auth_ok(request.authorized);
+  };
+  return { check: check };
+};
+
+authentication.read_only = function(){
+  function check(request, auth_ok, auth_no) {
+    metalog.event('cube_auth', { authenticator: 'read_only', path: request.url }, 'minor');
+    request.authorized = { admin: false };
+    return auth_ok(request.authorized);
+  };
+  return { check: check };
+};
+
+authentication.mongo_cookie = function(db, options){
+  var users;
+
+  db.collection(options["collection"]||"users", function(error, clxn){
+    if (error) throw(error);
+    // TODO: check if not collection?
+    users = clxn;
+  });
+
+  function check(request, auth_ok, auth_no) {
+    var cookie       = (new cookies(request)).get('_cube_session'),
+        token        = decodeURIComponent(cookie).split('--'), // token[0] = token uid, token[1] = token secret
+        token_uid    = new Buffer(token[0] + '', 'base64').toString('utf8'),
+        token_secret = new Buffer(token[1] + '', 'base64').toString('utf8');
+
+    metalog.event('cube_auth', { is: 'hi', tu: token_uid }, 'minor');
+
+    if (! (cookie && token && token_uid && token_secret)){
+      metalog.event('cube_auth', { is: 'no', r: 'no_token_in_request' });
+      auth_no('no_token_in_request');
+      return;
+    };
+
+    validate_token({"tokens.uid": token_uid}, auth_ok, auth_no);
+
+    function validate_token(query, auth_ok, auth_no){
+      // Asynchronously load the requested user.
+      users.findOne(query, function(error, user) {
+        if((!error) && user) {
+          metalog.event('cube_auth', { is: 'ok', tu: token_uid, u: user._id }, 'minor');
+          var auth_info = user.tokens.filter(function(t){ return t.uid === token_uid; });
+
+          if(auth_info.length === 1){
+            bcrypt.compare(token_secret, auth_info[0].hashed_secret, function(err, res) {
+              if (!err && res === true ){
+                delete auth_info[0].hashed_secret;
+                request.authorized = auth_info[0];
+                auth_ok(request.authorized);
+              } else {
+                metalog.event('cube_auth', { is: 'no', r: 'bad_token', tu: token_uid, u: user });
+                auth_no('bad_token');
+              }
+            });
+          } else {
+            metalog.event('cube_auth', { is: 'no', r: 'missing_token', tu: token_uid, u: user });
+            auth_no('missing_token');
+          }
+        } else {
+          metalog.event('cube_auth', { is: 'no', r: 'missing_user', tu: token_uid });
+          auth_no('missing_user');
+        };
+      });
+    };
+  };
+  return { check: check };
+};
+
+// base-64 encode a uid and bcrypted secret
+authentication.gen_cookie = function(session_name, uid, secret){
+  encoded_uid = new Buffer(uid,    'utf8').toString('base64');
+  encoded_sec = new Buffer(secret, 'utf8').toString('base64');
+  return (session_name+"="+encoded_uid+"--"+encoded_sec+";");
+};
+
+module.exports = authentication;

--- a/lib/cube/index.js
+++ b/lib/cube/index.js
@@ -1,3 +1,4 @@
+exports.metalog = require("./metalog");
 exports.emitter = require("./emitter");
 exports.server = require("./server");
 exports.collector = require("./collector");

--- a/lib/cube/index.js
+++ b/lib/cube/index.js
@@ -1,3 +1,4 @@
+exports.authentication = require("./authentication");
 exports.metalog = require("./metalog");
 exports.emitter = require("./emitter");
 exports.server = require("./server");

--- a/lib/cube/metalog.js
+++ b/lib/cube/metalog.js
@@ -1,0 +1,46 @@
+var util  = require("util");
+
+var metalog = {
+  putter:  null,
+  log:     util.log,
+  silent:  function(){ }
+}
+
+// adjust verboseness by reassigning `metalog.loggers.{level}`
+// @example: quiet all logs
+//   metalog.loggers.info = metalog.silent();
+metalog.loggers = {
+  info:  metalog.log,
+  minor: metalog.silent
+}
+
+// if true, cubify `metalog.event`s
+metalog.send_events = true;
+
+// Cubify an event and (optionally) log it. The last parameter specifies the
+// logger -- 'info' (the default), 'minor' or 'silent'.
+metalog.event = function(name, hsh, logger){
+  metalog[logger||"info"](name, hsh);
+  if ((! metalog.send_events) || (! metalog.putter)) return;
+  metalog.putter({ type: name, time: Date.now(), data: hsh });
+};
+
+// Events important enough for the production log file. Does not cubify.
+metalog.info = function(name, hsh){
+  metalog.loggers.info(name + "\t" + JSON.stringify(hsh));
+};
+
+// Debug-level statements; loggers.minor is typically mapped to 'silent'.
+metalog.minor = function(name, hsh){
+  metalog.loggers.minor(name + "\t" + JSON.stringify(hsh));
+};
+
+// Dump the 'util.inspect' view of each argument to the console.
+metalog.inspectify = function(args){
+  args = Array.prototype.slice.call(arguments);
+  args.map(function (arg){
+    util.debug(util.inspect(arg));
+  });
+};
+
+module.exports = metalog;

--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -1,3 +1,16 @@
+// Server -- generic HTTP, UDP and websockets server
+//
+// Used by the collector to accept new events via HTTP or websockets
+// Used by the evaluator to serve pages over HTTP, and the continuously-updating
+//   metrics stream over websockets
+//
+// holds
+// * the primary and secondary websockets connections
+// * the HTTP listener connection
+// * the MongoDB connection
+// * the UDP listener connection
+//
+
 var util = require("util"),
     url = require("url"),
     http = require("http"),
@@ -5,7 +18,8 @@ var util = require("util"),
     websocket = require("websocket"),
     websprocket = require("websocket-server"),
     static = require("node-static"),
-    mongodb = require("mongodb");
+    mongodb = require("mongodb"),
+    metalog = require("./metalog");
 
 // Don't crash on errors.
 process.on("uncaughtException", function(error) {
@@ -38,7 +52,6 @@ module.exports = function(options) {
       primary = http.createServer(),
       secondary = websprocket.createServer(),
       file = new static.Server("static"),
-      meta,
       endpoints = {ws: [], http: []},
       mongo = new mongodb.Server(options["mongo-host"], options["mongo-port"], server_options),
       db = new mongodb.Db(options["mongo-database"], mongo, db_options),
@@ -88,20 +101,10 @@ module.exports = function(options) {
           e.dispatch(JSON.parse(message.utf8Data || message), callback);
         });
 
-        meta({
-          type: "cube_request",
-          time: Date.now(),
-          data: {
-            ip: connection.remoteAddress,
-            path: request.url,
-            method: "WebSocket"
-          }
-        });
-
+        metalog.event('cube_request', { is: 'ws', method: "WebSocket", ip: connection.remoteAddress, path: request.url}, 'minor');
         return;
       }
     }
-
     connection.close();
   }
 
@@ -113,17 +116,7 @@ module.exports = function(options) {
     for (var i = -1, n = endpoints.http.length, e; ++i < n;) {
       if ((e = endpoints.http[i]).match(u.pathname, request.method)) {
         e.dispatch(request, response);
-
-        meta({
-          type: "cube_request",
-          time: Date.now(),
-          data: {
-            ip: request.connection.remoteAddress,
-            path: u.pathname,
-            method: request.method
-          }
-        });
-
+        metalog.event('cube_request', { method: request.method, ip: request.connection.remoteAddress, path: u.pathname });
         return;
       }
     }
@@ -132,6 +125,7 @@ module.exports = function(options) {
     request.on("end", function() {
       file.serve(request, response, function(error) {
         if (error) {
+          metalog.event('cube_request', { is: 'failed', msg: error, code: error.status, ip: request.connection.remoteAddress, path: u.pathname });
           response.writeHead(error.status, {"Content-Type": "text/plain"});
           response.end(error.status + "");
         }
@@ -141,11 +135,12 @@ module.exports = function(options) {
 
   server.start = function() {
     // Connect to mongodb.
-    util.log("starting mongodb client");
+    mongo_password = options["mongo-password"]; delete options["mongo-password"];
+    metalog.info('cube_life', {is: 'mongo_connect', options: options });
     db.open(function(error) {
       if (error) throw error;
       if (options["mongo-username"] == null) return ready();
-      db.authenticate(options["mongo-username"], options["mongo-password"], function(error, success) {
+      db.authenticate(options["mongo-username"], mongo_password, function(error, success) {
         if (error) throw error;
         if (!success) throw new Error("authentication failed");
         ready();
@@ -155,11 +150,11 @@ module.exports = function(options) {
     // Start the server!
     function ready() {
       server.register(db, endpoints);
-      meta = require("./event").putter(db);
-      util.log("starting http server on port " + options["http-port"]);
+      metalog.putter = require("./event").putter(db);
+      metalog.event("cube_life", { is: 'start_http', port: options["http-port"] });
       primary.listen(options["http-port"]);
       if (endpoints.udp) {
-        util.log("starting udp server on port " + options["udp-port"]);
+        metalog.event("cube_life", { is: 'start_udp', port: options["udp-port"] });
         var udp = dgram.createSocket("udp4");
         udp.on("message", function(message) {
           endpoints.udp(JSON.parse(message.toString("utf8")), ignore);

--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -19,6 +19,7 @@ var util = require("util"),
     websprocket = require("websocket-server"),
     static = require("node-static"),
     mongodb = require("mongodb"),
+    authentication = require("./authentication"),
     metalog = require("./metalog");
 
 // Don't crash on errors.
@@ -55,21 +56,42 @@ module.exports = function(options) {
       endpoints = {ws: [], http: []},
       mongo = new mongodb.Server(options["mongo-host"], options["mongo-port"], server_options),
       db = new mongodb.Db(options["mongo-database"], mongo, db_options),
-      id = 0;
+      id = 0,
+      authenticator;
 
   secondary.server = primary;
 
+  function is_sec_ws_initiation(request){
+    return ("sec-websocket-version" in request.headers);
+  }
+  function is_ws_initiation(request){
+    return (request.method === "GET"
+            && /^websocket$/i.test(request.headers.upgrade)
+            && /^upgrade$/i.test(request.headers.connection));
+  }
+
   // Register primary WebSocket listener with fallback.
   primary.on("upgrade", function(request, socket, head) {
-    if ("sec-websocket-version" in request.headers) {
-      request = new websocket.request(socket, request, wsOptions);
-      request.readHandshake();
-      connect(request.accept(request.requestedProtocols[0], request.origin), request.httpRequest);
-    } else if (request.method === "GET"
-        && /^websocket$/i.test(request.headers.upgrade)
-        && /^upgrade$/i.test(request.headers.connection)) {
-      new websprocket.Connection(secondary.manager, secondary.options, request, socket, head);
+    function auth_ok(perms) {
+      if (is_sec_ws_initiation(request)) {
+        request = new websocket.request(socket, request, wsOptions);
+        request.readHandshake();
+        connect(request.accept(request.requestedProtocols[0], request.origin), request.httpRequest);
+      } else if (is_ws_initiation(request)) {
+        new websprocket.Connection(secondary.manager, secondary.options, request, socket, head);
+      }
     }
+    function auth_no(perms) {
+      if (is_sec_ws_initiation(request)) {
+        request = new websocket.request(socket, request, wsOptions);
+        request.readHandshake();
+        request.reject();
+      } else if (is_ws_initiation(request)) {
+        res = 'HTTP/1.1 403 Forbidden\r\nConnection: close';
+        socket.end(res + '\r\n\r\n', 'ascii');
+      }
+    }
+    return authenticator.check(request, auth_ok, auth_no);
   });
 
   // Register secondary WebSocket listener.
@@ -81,6 +103,8 @@ module.exports = function(options) {
   });
 
   function connect(connection, request) {
+    // save auth from connection requesta
+    var authorization = request.authorized;
 
     // Forward messages to the appropriate endpoint, or close the connection.
     for (var i = -1, n = endpoints.ws.length, e; ++i < n;) {
@@ -98,7 +122,10 @@ module.exports = function(options) {
         });
 
         connection.on("message", function(message) {
-          e.dispatch(JSON.parse(message.utf8Data || message), callback);
+          // staple the authorization back on
+          var payload = JSON.parse(message.utf8Data || message);
+          payload.authorized = authorization;
+          e.dispatch(payload, callback);
         });
 
         metalog.event('cube_request', { is: 'ws', method: "WebSocket", ip: connection.remoteAddress, path: request.url}, 'minor');
@@ -115,9 +142,18 @@ module.exports = function(options) {
     // Forward messages to the appropriate endpoint, or 404.
     for (var i = -1, n = endpoints.http.length, e; ++i < n;) {
       if ((e = endpoints.http[i]).match(u.pathname, request.method)) {
-        e.dispatch(request, response);
-        metalog.event('cube_request', { method: request.method, ip: request.connection.remoteAddress, path: u.pathname });
-        return;
+
+        function auth_ok(perms) {
+          metalog.event('cube_request', { is: 'auth_ok', method: request.method, ip: request.connection.remoteAddress, path: u.pathname, auth: true, user: perms });
+          e.dispatch(request, response);
+        }
+        function auth_no(reason) {
+          metalog.event('cube_request', { is: 'auth_no', method: request.method, ip: request.connection.remoteAddress, path: u.pathname, auth: false });
+          response.writeHead(403, {"Content-Type": "text/plain"});
+          response.end("403 Forbidden");
+        }
+
+        return authenticator.check(request, auth_ok, auth_no);
       }
     }
 
@@ -151,6 +187,7 @@ module.exports = function(options) {
     function ready() {
       server.register(db, endpoints);
       metalog.putter = require("./event").putter(db);
+      authenticator  = authentication.authenticator(options["authenticator"], db, options);
       metalog.event("cube_life", { is: 'start_http', port: options["http-port"] });
       primary.listen(options["http-port"]);
       if (endpoints.udp) {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
   "repository": {"type": "git", "url": "http://github.com/square/cube.git"},
   "main": "./lib/cube",
   "dependencies": {
-    "mongodb": "1.0.1",
-    "node-static": "0.5.9",
-    "pegjs": "0.6.2",
-    "vows": "0.5.11",
-    "websocket": "1.0.3",
+    "mongodb":          "1.0.1",
+    "node-static":      "0.5.9",
+    "pegjs":            "0.6.2",
+    "vows":             "0.5.11",
+    "node-gyp":         "0.6.8",
+    "websocket":        "1.0.3",
     "websocket-server": "1.4.04"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "vows":             "0.5.11",
     "node-gyp":         "0.6.8",
     "websocket":        "1.0.3",
-    "websocket-server": "1.4.04"
+    "websocket-server": "1.4.04",
+    "cookies":          "0.3.1",
+    "bcrypt":           "0.7.1"
   }
 }

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -1,0 +1,169 @@
+var vows           = require("vows"),
+    assert         = require("assert"),
+    util           = require("util"),
+    metalog        = require("../lib/cube/metalog"),
+    authentication = require("../lib/cube/authentication"),
+    test_db        = require("./test_db"),
+    test           = require('./test');
+
+var suite = vows.describe("authentication");
+suite.options.error = true;
+
+//
+// Test Macros
+//
+
+function successful_auth(req) {
+  return function(authenticator){
+    var that = this;
+    that.req = req;
+    authenticator.check(req,
+                        function(arg){ that.callback(null, arg); },
+                        function(arg){ that.callback(new Error("Auth failed but should have succeeded")); });
+  };
+}
+
+function failed_auth(req) {
+  return function(authenticator){
+    var that = this;
+    that.req = req;
+    authenticator.check(req,
+                        function(arg){ that.callback("Auth succeeded but should have failed"); },
+                        function(arg){ that.callback(null, arg); } );
+  };
+}
+
+// as I'm sure you know: boss_hogg and luke have write access (luke doubly so);
+// roscoe can't do much but sit around; and it's as if coy & vance never existed
+var test_users = [
+  { _id: "boss_hogg", tokens: [{ uid: 'boss_hogg_tok', admin: true,  hashed_secret: "$2a$10$3u.CU4pJLnPDM7VwhJtbyuLwGBiOwpQ42q0wFQEDoJZtirAgIrBI6"}] },
+  { _id: "luke",      tokens: [{ uid: 'luke_tok',      admin: true,  hashed_secret: "$2a$10$K5NpLr3qrhxsUBW0iCw8iegQzgEINdWDk2n1BrTYe1x1Ay4dU2PlG"},
+                               { uid: 'luke_2_tok',    admin: true,  hashed_secret: "$2a$10$0I6KVPSzUIXdlxdY7qPTF.dde4tjPGRahYcja96Fz6ZaakEfdnNGO"}] },
+  { _id: "roscoe",    tokens: [{ uid: 'roscoe_tok',    admin: false, hashed_secret: "$2a$10$BKIqJukrlFtbjFeeLCnEvOwHdLMLDt61iyfMRLiEf9lNeWKD.djrm"}] },
+  { _id: "vance",     tokens: [] }
+];
+var dummy_token = "token_in_cookie";
+
+function dummy_request(username, token){
+  return({ headers: { cookie: authentication.gen_cookie("_cube_session", username+"_tok", token || dummy_token) } });
+};
+
+suite.addBatch(test_db.batch({
+
+  mongo_cookie: {
+    topic: test_db.using_objects("test_users", test_users, this.callback),
+    "": {
+      topic: function(test_db){
+        return authentication.authenticator("mongo_cookie", test_db.db, { collection: "test_users" }); },
+      "authenticates": {
+        "users with good tokens": {
+          topic: successful_auth(dummy_request("boss_hogg")),
+          '': function(result){ assert.deepEqual(this.req.authorized, { uid: 'boss_hogg_tok', admin: true }); }
+        },
+        "users with tokens, even if there are many": {
+          "a": {
+            topic: successful_auth(dummy_request("luke")),
+            '': function(result){ assert.deepEqual(this.req.authorized, { uid: 'luke_tok', admin: true }); }
+          },
+          "b": {
+            topic: successful_auth(dummy_request("luke_2")),
+            '': function(result){ assert.deepEqual(this.req.authorized, { uid: 'luke_2_tok', admin: true }); }
+          }
+        }
+      },
+      "request.authorized": {
+        "": {
+          topic: successful_auth(dummy_request("boss_hogg")),
+          'is stapled to the request object': function(result){
+            assert.isObject(this.req.authorized);
+            assert.deepEqual(this.req.authorized, { uid: 'boss_hogg_tok', admin: true });
+          },
+          'is returned as callback param': function(result){
+            assert.deepEqual(result, { uid: 'boss_hogg_tok', admin: true });
+          },
+        },
+        "user with write access": {
+          topic: successful_auth(dummy_request("boss_hogg")),
+          'request.authorized.admin is true': function(result){
+            assert.isTrue(this.req.authorized.admin);
+          }
+        },
+        "user with read-only access": {
+          topic: successful_auth(dummy_request("roscoe")),
+          'authenticates': function(result){
+            assert.deepEqual(this.req.authorized, { uid: 'roscoe_tok', admin: false }); },
+          'request.authorized.admin is false': function(result){
+            assert.isFalse(this.req.authorized.admin);
+          }
+        }
+      },
+      "does not allow": {
+        "bad token": {
+          topic: failed_auth(dummy_request("boss_hogg", "bad_token")),
+          "invokes auth_no callback with reason": function(reason){
+            assert.equal(reason, 'bad_token');
+          },
+          "does not authorize request": function(reason){ assert.isUndefined(this.req.authorized); }
+        },
+        "no token in request": {
+          topic: failed_auth({ headers: { cookie: "" } }),
+          "invokes auth_no callback with reason": function(reason){
+            assert.equal(reason, 'no_token_in_request');
+          },
+          "does not authorize request": function(reason){ assert.isUndefined(this.req.authorized); }
+        },
+        "user there, no auth record": {
+          topic: failed_auth(dummy_request("vance")),
+          "invokes auth_no callback with reason": function(reason){
+            assert.equal(reason, 'missing_user');
+          },
+          "does not authorize request": function(reason){ assert.isUndefined(this.req.authorized); }
+        },
+        "missing user": {
+          topic: failed_auth(dummy_request("coy")),
+          "invokes auth_no callback with reason": function(reason){
+            assert.equal(reason, 'missing_user');
+          },
+          "does not authorize request": function(reason){ assert.isUndefined(this.req.authorized); }
+        }
+      }
+    }
+  },
+
+  "allow_all": {
+    topic: function(test_db){
+      return authentication.authenticator("allow_all"); },
+    "calls the auth_ok callback immediately" : {
+      topic: successful_auth({type: "allow_all auth"}),
+      'decorates the request object': function(result){
+        assert.isObject(this.req.authorized);
+      },
+      'returns the authorization hash': function(result){
+        assert.deepEqual(result,              { admin: true });
+      },
+      'authorizes writes': function(result){
+        assert.deepEqual(this.req.authorized, { admin: true });
+      }
+    }
+  },
+
+  "read_only": {
+    topic: function(test_db){
+      return authentication.authenticator("read_only"); },
+    "calls the auth_ok callback immediately" : {
+      topic: successful_auth({type: "read_only auth"}),
+      'decorates the request object': function(result){
+        assert.isObject(this.req.authorized);
+      },
+      'returns the authorization hash': function(result){
+        assert.deepEqual(result,              { admin: false });
+      },
+      'authorizes writes': function(result){
+        assert.deepEqual(this.req.authorized, { admin: false });
+      }
+    }
+  }
+
+}));
+
+suite.export(module);

--- a/test/collector-test.js
+++ b/test/collector-test.js
@@ -9,7 +9,8 @@ var port = ++test.port, server = cube.server({
   "mongo-host": "localhost",
   "mongo-port": 27017,
   "mongo-database": "cube_test",
-  "http-port": port
+  "http-port": port,
+  "authenticator": "allow_all"
 });
 
 server.register = cube.collector.register;

--- a/test/metalog-test.js
+++ b/test/metalog-test.js
@@ -1,0 +1,122 @@
+var vows           = require("vows"),
+    assert         = require("assert"),
+    test           = require('./test');
+
+var suite = vows.describe("metalog");
+
+suite.with_log = function(batch){
+  suite.addBatch({
+    '':{
+      topic: function(){
+        var metalog = require("../lib/cube/metalog");
+        var logged = this.logged = { infoed: [], minored: [], putted: [] };
+        this.original = { send_events: metalog.send_events, putter: metalog.putter, info: metalog.loggers.info, minor: metalog.loggers.minor };
+        metalog.send_events   = true;
+        metalog.loggers.info  = function(line){ logged.infoed.push(line);  };
+        metalog.loggers.minor = function(line){ logged.minored.push(line); };
+        metalog.putter        = function(line){ logged.putted.push(line);  };
+        return metalog;
+      },
+      metalog: batch,
+      teardown: function(metalog){
+        metalog.loggers.info  = this.original.info;
+        metalog.loggers.minor = this.original.minor;
+        metalog.putter        = this.original.putter;
+      }
+    }
+  });
+  return suite;
+}
+
+suite.with_log({
+  '.info': {
+    'logs record to metalog.logers.info': function(metalog){
+      metalog.info('reactor_level', { criticality: 7, cores: 'leaking' });
+      assert.equal(this.logged.infoed.pop(), 'reactor_level\t{"criticality":7,"cores":"leaking"}');
+      assert.deepEqual(this.logged, { infoed: [], minored: [], putted: [] });
+    }
+  }
+}).with_log({
+  '.minor': {
+    'logs record to metalog.loggers.minor': function(metalog){
+      metalog.minor('reactor_level', { modacity: 3 });
+      assert.equal(this.logged.minored.pop(), 'reactor_level\t{"modacity":3}');
+      assert.deepEqual(this.logged, { infoed: [], minored: [], putted: [] });
+    }
+  }
+}).with_log({
+  '.event': {
+    'with send_events=true': {
+      topic: function(metalog){
+        metalog.send_events = true;
+        metalog.event('reactor_level', { criticality: 9, hemiconducers: 'relucting' });
+        return metalog;
+      },
+      'logs record to metalog.info by default': function(metalog){
+        assert.equal(this.logged.infoed.pop(), 'reactor_level\t{"criticality":9,"hemiconducers":"relucting"}');
+      },
+      'writes an event to cube itself': function(metalog){
+        event = this.logged.putted.pop();
+        event.time = 'whatever';
+        assert.deepEqual(event, {
+          data: { hemiconducers: 'relucting', criticality: 9 },
+          type: 'reactor_level',
+          time: 'whatever'
+        });
+      }
+    }
+  }
+}).with_log({
+  '.event': {
+    'with send_events=false': {
+      topic: function(metalog){
+        metalog.send_events = false;
+        metalog.event('reactor_level', { criticality: 10, hemiconducers: 'fremulating' });
+        return metalog;
+      },
+      'logs record to metalog.loggers.info': function(metalog){
+        assert.equal(this.logged.infoed.pop(), 'reactor_level\t{"criticality":10,"hemiconducers":"fremulating"}');
+      },
+      'does not write an event to cube': function(metalog){
+        assert.deepEqual(this.logged, { infoed: [], minored: [], putted: [] });
+      }
+    }
+  }
+}).with_log({
+  '.event': {
+    'last parameter overrides log target': {
+      topic: function(metalog) {
+        metalog.send_events = true;
+        metalog.event('reactor_level', { criticality: 3, hemiconducers: 'cromulent' }, 'minor');
+        metalog.event('reactor_level', { criticality: 2, hemiconducers: 'whispery'  }, 'silent');
+        return metalog;
+      },
+      '': function(metalog){
+        assert.equal(this.logged.minored.pop(), 'reactor_level\t{"criticality":3,"hemiconducers":"cromulent"}');
+        assert.equal(this.logged.putted.pop().data.criticality, 2);
+        assert.equal(this.logged.putted.pop().data.criticality, 3);
+        assert.deepEqual(this.logged, { infoed: [], minored: [], putted: [] });
+      }
+    }
+  }
+});
+
+function dummy_logger(arg){};
+
+suite.addBatch({
+  'metalog':{
+    topic: function(){ return require("../lib/cube/metalog"); },
+    '': {
+      'loggers persist across factory invocation': function(metalog){
+        metalog.orig_minor    = metalog.loggers.minor;
+        metalog.loggers.minor = dummy_logger;
+        var ml2 = require("../lib/cube/metalog");
+        assert.deepEqual(metalog, ml2);
+        assert.deepEqual(metalog.loggers.minor,    dummy_logger);
+        assert.notDeepEqual(metalog.loggers.minor, metalog.orig_minor);
+      },
+      teardown: function(metalog){ metalog.loggers.minor = metalog.orig_minor; }
+    }
+  }});
+
+suite.export(module);

--- a/test/test.js
+++ b/test/test.js
@@ -1,37 +1,13 @@
 var mongodb = require("mongodb"),
-    assert = require("assert"),
-    util = require("util"),
-    http = require("http");
+    assert  = require("assert"),
+    util    = require("util"),
+    metalog = require("../lib/cube/metalog"),
+    test_db = require("./test_db"),
+    http    = require("http");
 
 exports.port = 1083;
 
-exports.batch = function(batch) {
-  return {
-    "": {
-      topic: function() {
-        var client = new mongodb.Server("localhost", 27017);
-            db = new mongodb.Db("cube_test", client),
-            cb = this.callback;
-        db.open(function(error) {
-          var collectionsRemaining = 2;
-          db.dropCollection("test_events", collectionReady);
-          db.dropCollection("test_metrics", collectionReady);
-          function collectionReady() {
-            if (!--collectionsRemaining) {
-              cb(null, {client: client, db: db});
-            }
-          }
-        });
-      },
-      "": batch,
-      teardown: function(test) {
-        if (test.client.isConnected()) {
-          test.client.close();
-        }
-      }
-    }
-  };
-};
+exports.batch = test_db.batch;
 
 exports.request = function(options, data) {
   return function() {
@@ -54,4 +30,7 @@ exports.request = function(options, data) {
 };
 
 // Disable logging for tests.
+metalog.loggers.info  = metalog.silent;
+metalog.loggers.minor = metalog.silent;
 util.log = function() {};
+metalog.send_events = false;

--- a/test/test_db.js
+++ b/test/test_db.js
@@ -1,0 +1,75 @@
+var mongodb        = require("mongodb"),
+    util           = require("util"),
+    metalog        = require("../lib/cube/metalog");
+
+var test_db = { };
+
+var test_collections = ["test_users", "test_events", "test_metrics"];
+
+var options = exports.options = {
+  "mongo-host":     "localhost",
+  "mongo-port":     27017,
+  "mongo-database": "cube_test"
+};
+
+exports.using_objects = function (clxn_name, test_objects){
+  metalog.minor('cube_testdb', {state: 'loading test objects', test_objects: test_objects });
+  return function(tdb){
+    var that = this;
+    tdb.db.collection(clxn_name, function(err, clxn){
+      if (err) throw(err);
+      that[clxn_name] = clxn;
+      clxn.remove({ dummy: true }, {safe: true}, function(){
+        clxn.insert(test_objects, { safe: true }, function(){
+          that.callback(null);
+        }); });
+    });
+  };
+};
+
+exports.batch = function(batch) {
+  return {
+    "": {
+      topic: function() {
+        connect();
+        setup_db(this.callback);
+      },
+      "": batch,
+      teardown: function(test) {
+        if (test.client.isConnected()) {
+          process.nextTick(function(){ test.client.close(); });
+        };
+      }
+    }
+  };
+};
+
+//
+// db methods
+//
+
+function setup_db(cb){
+  drop_collections(cb);
+}
+
+function connect(){
+  metalog.minor('cube_testdb', { state: 'connecting to db', options: options });
+  test_db.options = options;
+  test_db.client  = new mongodb.Server(options["mongo-host"], options["mongo-port"], {auto_reconnect: true});
+  test_db.db      = new mongodb.Db(options["mongo-database"], test_db.client, {});
+}
+
+function drop_collections(cb){
+  metalog.minor('cube_testdb', { state: 'dropping test collections', collections: test_collections });
+  test_db.db.open(function(error) {
+    var collectionsRemaining = test_collections.length;
+    test_collections.forEach(function(collection_name){
+      test_db.db.dropCollection(collection_name,  collectionReady);
+    });
+    function collectionReady() {
+      if (!--collectionsRemaining) {
+        cb(null, test_db);
+      }
+    }
+  });
+}


### PR DESCRIPTION
@hustonhoburg added authentication and lightweight authorization. It's low-fuss enough that you might consider it for mainline.
- authentication.authenticator(name) gives you the requested authenticator
  - server.js uses options['authenticator']
  - 'allow_all' is default in bin/collector-config.js etc.
- authenticator.check(request, auth_ok, auth_no)
  - calls auth_ok if authenticated, auth_no if rejected
  - staples an 'authorized' member to the request object:
    - eg we use 'request.authorized.admin' to govern board editing
    - in the mongo_cookie authenticator, it's the user record
- mongo_cookie authenticator compares bcrypted cookie to a stored hashed secret

You must set the cookie and store that db record in your host client; see 'test/authenticator-test.js' for format. Rails+devise snippet available on request.

_Note: the second patch lays in the auth stuff, so it may be helpful to look at it on its own. The first commit of this pull request lays in basic metalogging stuff from #91. I took some care to make it a reduced set of shared changes; this and #91 will merge cleanly._
