### PR TITLE
Update node-static dependency due to deprecated use of sys

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "./lib/cube",
   "dependencies": {
     "mongodb": "1.0.1",
-    "node-static": "0.5.9",
+    "node-static": "0.6.1",
     "pegjs": "0.6.2",
     "vows": "0.5.11",
     "websocket": "1.0.3",


### PR DESCRIPTION
With recent versions of node.js, `sys` is now replaced by `util`.  node-static 0.5.9 relied on `sys` but was fixed in [later versions](https://github.com/cloudhead/node-static/commit/b184ea489ed9599037396ee56917781fe91e7b95).  Updated package.json to remedy this.

Running on node v0.8.0 using the version of node-static in the old package.json:

![screen shot](http://cl.ly/image/041T0t093d1G/Screen%20Shot%202012-08-30%20at%208.07.40%20PM.png)
