### PR TITLE
Fix cube server for node v0.10 

### DIFF
--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -137,6 +137,11 @@ module.exports = function(options) {
         }
       });
     });
+
+    // as of node v0.10, 'end' is not emitted unless read() called
+    if (request.read !== undefined) {
+      request.read();
+    }
   });
 
   server.start = function() {


### PR DESCRIPTION
The `on('end')` is never being called, thus the evaluator is hanging and not returning any response to HTTP requests.

Relevant issues in node can be found here:
https://github.com/joyent/node/issues/4942

This is the commit which caused the change:
https://github.com/joyent/node/commit/327b6e3e1de88ba1db83142d53b3a57f0d06d519#lib/http.js

I have tested this out on node `v0.8.21` and `v0.10.1`
