### PR TITLE
Fix for including Mongo id in event response 

### DIFF
--- a/lib/cube/event.js
+++ b/lib/cube/event.js
@@ -188,7 +188,7 @@ exports.getter = function(db) {
           handle(error);
 
           // A null event indicates that there are no more results.
-          if (event) callback({id: event._id instanceof ObjectID ? undefined : event._id, time: event.t, data: event.d});
+          if (event) callback({id: event._id instanceof ObjectID ? event._id : undefined, time: event.t, data: event.d});
           else callback(null);
         });
       });


### PR DESCRIPTION
It looks like this was implemented backwards.  Fixing as it was causing us some hair-pulling moments.
