### PR TITLE
Addition of option to allow events to expire after a certain time

### DIFF
--- a/lib/cube/event.js
+++ b/lib/cube/event.js
@@ -68,7 +68,7 @@ exports.putter = function(db) {
 
       // Events are indexed by time.
       if (expireEventsAfterSeconds) {
-      // Events are indexed by time and expired after a supplied period (expireEventsAfterSeconds).
+        // Events are indexed by time and expired after a supplied period (expireEventsAfterSeconds).
         events.ensureIndex({"t": 1},  { expireAfterSeconds: expireEventsAfterSeconds }, handle);
       }
       else {

--- a/lib/cube/event.js
+++ b/lib/cube/event.js
@@ -66,14 +66,14 @@ exports.putter = function(db) {
       var events = collection(type).events;
       if (names.length) return saveEvents();
 
-    // Events are indexed by time.
-    if (expireEventsAfterSeconds) {
-    // Events are indexed by time and expired after a supplied period (expireEventsAfterSeconds).
-      events.ensureIndex({"t": 1},  { expireAfterSeconds: expireEventsAfterSeconds }, handle);
-    }
-    else {
-      events.ensureIndex({"t": 1}, handle);
-	}
+      // Events are indexed by time.
+      if (expireEventsAfterSeconds) {
+      // Events are indexed by time and expired after a supplied period (expireEventsAfterSeconds).
+        events.ensureIndex({"t": 1},  { expireAfterSeconds: expireEventsAfterSeconds }, handle);
+      }
+      else {
+        events.ensureIndex({"t": 1}, handle);
+      }
 
       // Create a capped collection for metrics. Three indexes are required: one
       // for finding metrics, one (_id) for updating, and one for invalidation.

--- a/lib/cube/event.js
+++ b/lib/cube/event.js
@@ -6,7 +6,8 @@ var mongodb = require("mongodb"),
     tiers = require("./tiers"),
     types = require("./types"),
     bisect = require("./bisect"),
-    ObjectID = mongodb.ObjectID;
+    ObjectID = mongodb.ObjectID,
+	collector_config = require("../../bin/collector-config");
 
 var type_re = /^[a-z][a-zA-Z0-9_]+$/,
     invalidate = {$set: {i: true}},
@@ -21,6 +22,9 @@ var streamDelayDefault = 5000,
 
 // How frequently to invalidate metrics after receiving events.
 var invalidateInterval = 5000;
+
+// Set the Time To Live interval in seconds from the collector config
+var expireEventsAfterSeconds = collector_config.event_ttl_seconds;
 
 exports.putter = function(db) {
   var collection = types(db),
@@ -63,7 +67,13 @@ exports.putter = function(db) {
       if (names.length) return saveEvents();
 
       // Events are indexed by time.
-      events.ensureIndex({"t": 1}, handle);
+	  if (expireEventsAfterSeconds) {
+		// Events are indexed by time and expired after a supplied period (expireEventsAfterSeconds).
+		events.ensureIndex({"t": 1},  { expireAfterSeconds: expireEventsAfterSeconds }, handle);
+	  }
+	  else {
+		events.ensureIndex({"t": 1}, handle);
+	  }
 
       // Create a capped collection for metrics. Three indexes are required: one
       // for finding metrics, one (_id) for updating, and one for invalidation.

--- a/lib/cube/event.js
+++ b/lib/cube/event.js
@@ -7,7 +7,7 @@ var mongodb = require("mongodb"),
     types = require("./types"),
     bisect = require("./bisect"),
     ObjectID = mongodb.ObjectID,
-	collector_config = require("../../bin/collector-config");
+    collector_config = require("../../bin/collector-config");
 
 var type_re = /^[a-z][a-zA-Z0-9_]+$/,
     invalidate = {$set: {i: true}},
@@ -66,14 +66,14 @@ exports.putter = function(db) {
       var events = collection(type).events;
       if (names.length) return saveEvents();
 
-      // Events are indexed by time.
-	  if (expireEventsAfterSeconds) {
-		// Events are indexed by time and expired after a supplied period (expireEventsAfterSeconds).
-		events.ensureIndex({"t": 1},  { expireAfterSeconds: expireEventsAfterSeconds }, handle);
-	  }
-	  else {
-		events.ensureIndex({"t": 1}, handle);
-	  }
+    // Events are indexed by time.
+    if (expireEventsAfterSeconds) {
+    // Events are indexed by time and expired after a supplied period (expireEventsAfterSeconds).
+      events.ensureIndex({"t": 1},  { expireAfterSeconds: expireEventsAfterSeconds }, handle);
+    }
+    else {
+      events.ensureIndex({"t": 1}, handle);
+	}
 
       // Create a capped collection for metrics. Three indexes are required: one
       // for finding metrics, one (_id) for updating, and one for invalidation.


### PR DESCRIPTION
Added the ability to specify a value for MongoDb's expireAfterSeconds property.

This can help reduce the volume of data in the database at any one time. From http://docs.mongodb.org/manual/tutorial/expire-data/: "This is ideal for some types of information like machine generated event data, logs, and session information that only need to persist in a database for a limited period of time."

The value is optional and is set in the collector-config file.
