### PR TITLE
Add option to specify the path to the static directory

### DIFF
--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -34,7 +34,7 @@ module.exports = function(options) {
   var server = {},
       primary = http.createServer(),
       secondary = websprocket.createServer(),
-      file = new static.Server("static"),
+      file = new static.Server(options["static"] || "static"),
       meta,
       endpoints = {ws: [], http: []},
       id = 0;


### PR DESCRIPTION
It is a pain to have to start the collector/evaluator from the cube bin directory.
This is especially true when you have a custom config.  This small change allows you
to define a "static" option as part of your config to define the path to the cube
static directory.

Usage:

``` javascript
var config = {"static": "../node_modules/cube/static"};
var server = cube.server(config);
...
```
