### PR TITLE
Make static setup less brittle

### DIFF
--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -1,4 +1,5 @@
 var util = require("util"),
+    path = require("path"),
     url = require("url"),
     http = require("http"),
     dgram = require("dgram"),
@@ -34,7 +35,7 @@ module.exports = function(options) {
   var server = {},
       primary = http.createServer(),
       secondary = websprocket.createServer(),
-      file = new static.Server("static"),
+      file = new static.Server(path.join(__dirname, "..", "..", "static")),
       meta,
       endpoints = {ws: [], http: []},
       id = 0;


### PR DESCRIPTION
The path to the static directory is no longer the relative path of "static", making using the web interface less brittle when starting up evaluator.
