### PR TITLE
Added config options to allow binding servers to a particular interface

### DIFF
--- a/bin/collector-config.js
+++ b/bin/collector-config.js
@@ -6,5 +6,7 @@ module.exports = {
   "mongo-username": null,
   "mongo-password": null,
   "http-port": 1080,
-  "udp-port": 1180
+  "http-host": null,
+  "udp-port": 1180,
+  "udp-host": null
 };

--- a/bin/evaluator-config.js
+++ b/bin/evaluator-config.js
@@ -5,5 +5,6 @@ module.exports = {
   "mongo-database": "cube_development",
   "mongo-username": null,
   "mongo-password": null,
-  "http-port": 1081
+  "http-port": 1081,
+  "http-host": null
 };

--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -146,15 +146,15 @@ module.exports = function(options) {
       if (error) throw error;
       server.register(db, endpoints);
       meta = require("./event").putter(db);
-      util.log("starting http server on port " + options["http-port"]);
-      primary.listen(options["http-port"]);
+      util.log("starting http server on port " + (options['http-host'] ? options['http-host'] : '*') + ":" + options["http-port"]);
+      primary.listen(options["http-port"], options['http-host']);
       if (endpoints.udp) {
-        util.log("starting udp server on port " + options["udp-port"]);
+        util.log("starting udp server on port " + (options['udp-host'] ? options['udp-host'] : '*') + ":" + options["udp-port"]);
         var udp = dgram.createSocket("udp4");
         udp.on("message", function(message) {
           endpoints.udp(JSON.parse(message.toString("utf8")), ignore);
         });
-        udp.bind(options["udp-port"]);
+        udp.bind(options["udp-port"], options["udp-host"]);
       }
     });
   };


### PR DESCRIPTION
If you have a external and internal interface on a cube server you probably don't want to accept any traffic on the external interface. The simplest way to achieve this is to bind to an IP when starting the server. This pull adds and implements these additional options. If unset or null behaviour is unchanged (listen on all), if set servers are bound to that host.
