### PR TITLE
Allow one to specify a bind address for http, udp, fixes problem when udp disabled.

### DIFF
--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -146,8 +146,15 @@ module.exports = function(options) {
       if (error) throw error;
       server.register(db, endpoints);
       meta = require("./event").putter(db);
-      util.log("starting http server on port " + options["http-port"]);
-      primary.listen(options["http-port"]);
+      var http_addr = options["http-addr"];
+      util.log("starting http server on " +
+	       (http_addr !== undefined ? http_addr : "*") + ":" +
+	       options["http-port"]);
+      if (http_addr !== undefined) {
+	  primary.listen(options["http-port"], http_addr);
+      } else {
+	  primary.listen(options["http-port"]);
+      }
       if (endpoints.udp) {
         util.log("starting udp server on port " + options["udp-port"]);
         var udp = dgram.createSocket("udp4");

--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -148,14 +148,12 @@ module.exports = function(options) {
       meta = require("./event").putter(db);
       var http_addr = options["http-addr"];
       if (http_addr === undefined) http_addr = "0.0.0.0";
-      util.log("starting http server on " + http_addr + ":" +
-	       options["http-port"]);
+      util.log("starting http server on " + http_addr + ":" + options["http-port"]);
       primary.listen(options["http-port"], http_addr);
       if (endpoints.udp && options["udp-port"] !== undefined) {
-	var udp_addr = options["udp-addr"];
-	if (udp_addr === undefined) udp_addr = "0.0.0.0";
-        util.log("starting udp server on " + udp_addr + ":" +
-		 options["udp-port"]);
+        var udp_addr = options["udp-addr"];
+        if (udp_addr === undefined) udp_addr = "0.0.0.0";
+        util.log("starting udp server on " + udp_addr + ":" + options["udp-port"]);
         var udp = dgram.createSocket("udp4");
         udp.on("message", function(message) {
           endpoints.udp(JSON.parse(message.toString("utf8")), ignore);

--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -156,12 +156,15 @@ module.exports = function(options) {
 	  primary.listen(options["http-port"]);
       }
       if (endpoints.udp && options["udp-port"] !== undefined) {
-        util.log("starting udp server on port " + options["udp-port"]);
+	var udp_addr = options["udp-addr"];
+	if (udp_addr === undefined) udp_addr = "0.0.0.0";
+        util.log("starting udp server on " + udp_addr + ":" +
+		 options["udp-port"]);
         var udp = dgram.createSocket("udp4");
         udp.on("message", function(message) {
           endpoints.udp(JSON.parse(message.toString("utf8")), ignore);
         });
-        udp.bind(options["udp-port"]);
+        udp.bind(options["udp-port"], udp_addr);
       }
     });
   };

--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -147,14 +147,10 @@ module.exports = function(options) {
       server.register(db, endpoints);
       meta = require("./event").putter(db);
       var http_addr = options["http-addr"];
-      util.log("starting http server on " +
-	       (http_addr !== undefined ? http_addr : "*") + ":" +
+      if (http_addr === undefined) http_addr = "0.0.0.0";
+      util.log("starting http server on " + http_addr + ":" +
 	       options["http-port"]);
-      if (http_addr !== undefined) {
-	  primary.listen(options["http-port"], http_addr);
-      } else {
-	  primary.listen(options["http-port"]);
-      }
+      primary.listen(options["http-port"], http_addr);
       if (endpoints.udp && options["udp-port"] !== undefined) {
 	var udp_addr = options["udp-addr"];
 	if (udp_addr === undefined) udp_addr = "0.0.0.0";

--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -155,7 +155,7 @@ module.exports = function(options) {
       } else {
 	  primary.listen(options["http-port"]);
       }
-      if (endpoints.udp) {
+      if (endpoints.udp && options["udp-port"] !== undefined) {
         util.log("starting udp server on port " + options["udp-port"]);
         var udp = dgram.createSocket("udp4");
         udp.on("message", function(message) {


### PR DESCRIPTION
This is useful to only listen on loopback.

Syntax in your config would look like:
"http-addr": "127.0.0.1"

You can also specify a udp-addr now.
