### PR TITLE
Replace unpublished websocket-server

### DIFF
--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -3,12 +3,12 @@ var util = require("util"),
     http = require("http"),
     dgram = require("dgram"),
     websocket = require("websocket"),
-    websprocket = require("websocket-server"),
+    websprocket = require("node-websocket-server"),
     static = require("node-static"),
     database = require('./database');
 
 // And then this happened:
-websprocket.Connection = require("../../node_modules/websocket-server/lib/ws/connection");
+websprocket.Connection = require("../../node_modules/node-websocket-server/lib/ws/connection");
 
 // Configuration for WebSocket requests.
 var wsOptions =  {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "pegjs": "0.7.0",
     "vows": "0.7.0",
     "websocket": "1.0.8",
-    "websocket-server": "1.4.04"
+    "node-websocket-server": "0.0.1"
   }
 }


### PR DESCRIPTION
Tried to install cube but installation failed with this message

```
$ npm install
npm ERR! 404 Not Found
npm ERR! 404 
npm ERR! 404 'websocket-server' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it
npm ERR! 404 It was specified as a dependency of 'cube'
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, or http url, or git url.

npm ERR! System Linux 3.2.0-23-generic
npm ERR! command "/usr/bin/node" "/usr/bin/npm" "install"
npm ERR! cwd /home/vagrant/cube
npm ERR! node -v v0.10.32
npm ERR! npm -v 1.4.28
npm ERR! code E404
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/vagrant/cube/npm-debug.log
npm ERR! not ok code 0
```

After that I searched npm for websocket-server https://www.npmjs.org/package/websocket-server and found out that this package was unpublished.

Also in search results I found package https://www.npmjs.org/package/node-websocket-server which has in description mention that package replaces websocket-server.

So I decided to fix this issue replacing websocket-server with node-websocket-server.
