### PR TITLE
Replaces (unpublished) websocket-server with 'ws' module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .jshintrc
+.idea
 Procfile

--- a/lib/cube/server.js
+++ b/lib/cube/server.js
@@ -3,12 +3,9 @@ var util = require("util"),
     http = require("http"),
     dgram = require("dgram"),
     websocket = require("websocket"),
-    websprocket = require("websocket-server"),
+    WebSocketServer = require("ws").Server,
     static = require("node-static"),
     database = require('./database');
-
-// And then this happened:
-websprocket.Connection = require("../../node_modules/websocket-server/lib/ws/connection");
 
 // Configuration for WebSocket requests.
 var wsOptions =  {
@@ -33,26 +30,13 @@ module.exports = function(options) {
 
   var server = {},
       primary = http.createServer(),
-      secondary = websprocket.createServer(),
+      secondary = new WebSocketServer({ server: primary }),
       file = new static.Server("static"),
       meta,
       endpoints = {ws: [], http: []},
       id = 0;
 
   secondary.server = primary;
-
-  // Register primary WebSocket listener with fallback.
-  primary.on("upgrade", function(request, socket, head) {
-    if ("sec-websocket-version" in request.headers) {
-      request = new websocket.request(socket, request, wsOptions);
-      request.readHandshake();
-      connect(request.accept(request.requestedProtocols[0], request.origin), request.httpRequest);
-    } else if (request.method === "GET"
-        && /^websocket$/i.test(request.headers.upgrade)
-        && /^upgrade$/i.test(request.headers.connection)) {
-      new websprocket.Connection(secondary.manager, secondary.options, request, socket, head);
-    }
-  });
 
   // Register secondary WebSocket listener.
   secondary.on("connection", function(connection) {

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
     "type": "git",
     "url": "http://github.com/square/cube.git"
   },
+  "scripts":{"test":"./node_modules/.bin/vows"},
   "main": "./lib/cube",
   "dependencies": {
-    "mongodb": "~1.3.18",
+    "mongodb": "^1.4",
     "node-static": "0.6.5",
     "pegjs": "0.7.0",
     "vows": "0.7.0",
     "websocket": "1.0.8",
-    "websocket-server": "1.4.04"
+    "ws": "^0.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "A system for analyzing time series data using MongoDB and Node.",
   "keywords": [
     "time series"


### PR DESCRIPTION
Now using the 'ws' module. This module could also replace 'websocket' as well, but I won't bother with that for now.

Removed http 'upgrade' listener as it seems it is unneeded with the 'ws' module. 

All vows tests run successfully. 
